### PR TITLE
ci: add context when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ workflows:
           requires:
             - dependencies
       - snapshot_release:
+          context: html-tools
           requires:
             - dependencies
             - tests
@@ -88,6 +89,7 @@ workflows:
             branches:
               only: develop
       - release:
+          context: html-tools
           requires:
             - dependencies
             - tests
@@ -95,5 +97,6 @@ workflows:
             branches:
               only: master
       - github_release:
+          context: html-tools
           requires:
             - release


### PR DESCRIPTION
The github release script failed because we didn't have our env variables set up. This should fix it.
https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/197/workflows/d092cacf-e54b-471f-8129-8d4ef8ef8716/jobs/391

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
