### PR TITLE
chore: add `dependabot` config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+      - "deps_bot" # this is to help our PR list to filter
+  - package_manager: "java:maven"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+      - "deps_bot" # this is to help our PR list to filter

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,11 +2,11 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "weekly"
     default_labels:
-      - "axe_api_deps_bot" # this is to help our PR list to filter
+      - "axe_api_deps_bot"
   - package_manager: "java:maven"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "weekly"
     default_labels:
-      - "axe_api_deps_bot" # this is to help our PR list to filter
+      - "axe_api_deps_bot"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,9 +4,9 @@ update_configs:
     directory: "/"
     update_schedule: "daily"
     default_labels:
-      - "deps_bot" # this is to help our PR list to filter
+      - "axe_api_deps_bot" # this is to help our PR list to filter
   - package_manager: "java:maven"
     directory: "/"
     update_schedule: "daily"
     default_labels:
-      - "deps_bot" # this is to help our PR list to filter
+      - "axe_api_deps_bot" # this is to help our PR list to filter


### PR DESCRIPTION
This makes it easier to manage dependabot alerts than their UI.
> The `axe_api_deps_bot` label will help easily filter PR's opened by dependabot.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Code is reviewed for security
