### PR TITLE
feat: add full context to axe errors

### DIFF
--- a/src/main/java/com/deque/html/axecore/results/AxeRuntimeException.java
+++ b/src/main/java/com/deque/html/axecore/results/AxeRuntimeException.java
@@ -7,7 +7,7 @@ package com.deque.html.axecore.results;
 public class AxeRuntimeException extends RuntimeException {
   private static final long serialVersionUID = -123456789087654L;
 
-  public AxeRuntimeException(String message) {
-    super(message);
+  public AxeRuntimeException(Exception cause) {
+    super("Error when running axe", cause);
   }
 }

--- a/src/main/java/com/deque/html/axecore/results/Results.java
+++ b/src/main/java/com/deque/html/axecore/results/Results.java
@@ -17,27 +17,27 @@ public class Results {
     private List<Rule> incomplete;
     private List<Rule> inapplicable;
     // The error message from `axe.run()`
-    private Exception errorMessage;
+    private AxeRuntimeException errorObject;
 
     public boolean isErrored() {
-      return errorMessage != null;
+      return errorObject != null;
     }
 
-    public void setErrorMessage(final Exception errorMessage) {
-      this.errorMessage = errorMessage;
+    public void setErrorMessage(final Exception errorObject) {
+      this.errorObject = new AxeRuntimeException(errorObject);
     }
 
     public String getErrorMessage() {
-      if (errorMessage == null) {
+      if (errorObject == null) {
         return null;
       }
-      return errorMessage.toString();
+      return errorObject.getCause().toString();
     }
 
     @JsonIgnore
     public AxeRuntimeException getError() {
       if (this.isErrored()) {
-        return new AxeRuntimeException(errorMessage);
+        return errorObject;
       }
 
       return null;

--- a/src/main/java/com/deque/html/axecore/results/Results.java
+++ b/src/main/java/com/deque/html/axecore/results/Results.java
@@ -1,4 +1,5 @@
 package com.deque.html.axecore.results;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.List;
@@ -16,21 +17,25 @@ public class Results {
     private List<Rule> incomplete;
     private List<Rule> inapplicable;
     // The error message from `axe.run()`
-    private String errorMessage;
+    private Exception errorMessage;
 
-    public boolean isErrored () {
+    public boolean isErrored() {
       return errorMessage != null;
     }
 
-    public void setErrorMessage (final String errorMessage) {
+    public void setErrorMessage(final Exception errorMessage) {
       this.errorMessage = errorMessage;
     }
 
-    public String getErrorMessage () {
-      return errorMessage;
+    public String getErrorMessage() {
+      if (errorMessage == null) {
+        return null;
+      }
+      return errorMessage.toString();
     }
 
-    public AxeRuntimeException getError () {
+    @JsonIgnore
+    public AxeRuntimeException getError() {
       if (this.isErrored()) {
         return new AxeRuntimeException(errorMessage);
       }

--- a/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
+++ b/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
@@ -13,13 +13,19 @@
 package com.deque.html.axecore.selenium;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import javax.naming.OperationNotSupportedException;
 import org.json.JSONObject;
 import org.openqa.selenium.InvalidArgumentException;
+import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -79,13 +85,7 @@ public class AxeBuilder {
     "axe.run(context, options, function (err, results) {" +
     "  {" +
     "    if (err) {" +
-    "      results = {" +
-    "        violations: []," +
-    "        passes: []," +
-    "        url: ''," +
-    "        timestamp: new Date().toString()," +
-    "        errorMessage: err.message" +
-    "      }" +
+    "      throw new Error(err);" +
     "    }" +
     "    callback(results);" +
     "  }" +
@@ -439,8 +439,22 @@ public class AxeBuilder {
     webDriver.manage().timeouts()
         .setScriptTimeout(timeout, TimeUnit.SECONDS);
 
-    Object response = ((JavascriptExecutor) webDriver)
+    Object response = null;
+    try {
+      response = ((JavascriptExecutor) webDriver)
         .executeAsyncScript(axeRunScript, rawArgs);
+    } catch (JavascriptException je) {
+      // Formatted to match what you get if you run `new Date().toString()` in JS
+      SimpleDateFormat df = new SimpleDateFormat("E MMM dd yyyy HH:mm:ss 'GMT'XX (zzzz)");
+      String dateTime = df.format(new Date());
+      Results results = new Results();
+      results.setViolations(new ArrayList<>());
+      results.setPasses(new ArrayList<>());
+      results.setUrl("");
+      results.setTimestamp(dateTime);
+      results.setErrorMessage(je);
+      return results;
+    }
 
     Results results = objectMapper.convertValue(response, Results.class);
     return results;


### PR DESCRIPTION
Changes the `errorMessage` type in the `Results` object from `String` to `AxeRuntimeException` so that full stack trace is preserved. When converted to JSON it still has the same shape. However, the `errorMessage` property of the JSON will now contain the full stack trace rather than just a one-line description. When there is no error the JSON is unchanged.

Captures all selenium errors thrown when running axe-core as well.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Code is reviewed for security
