### PR TITLE
fix: Recursively find <frame>

### DIFF
--- a/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
+++ b/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
@@ -167,7 +167,7 @@ public final class WebDriverInjectorExtensions {
     JavascriptExecutor js = (JavascriptExecutor) driver;
     List<WebElement> frames = driver.findElements(By.tagName("iframe"));
     frames.addAll(driver.findElements(By.tagName("frame")));
-    
+
     for (WebElement frame : frames) {
       driver.switchTo().defaultContent();
 

--- a/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
+++ b/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
@@ -114,6 +114,7 @@ public final class WebDriverInjectorExtensions {
       final String script, final List<WebElement> parents) {
     JavascriptExecutor js = (JavascriptExecutor) driver;
     List<WebElement> frames = driver.findElements(By.tagName("iframe"));
+    frames.addAll(driver.findElements(By.tagName("frame")));
 
     for (WebElement frame : frames) {
       driver.switchTo().defaultContent();
@@ -165,7 +166,8 @@ public final class WebDriverInjectorExtensions {
       final String script, final List<WebElement> parents) {
     JavascriptExecutor js = (JavascriptExecutor) driver;
     List<WebElement> frames = driver.findElements(By.tagName("iframe"));
-
+    frames.addAll(driver.findElements(By.tagName("frame")));
+    
     for (WebElement frame : frames) {
       driver.switchTo().defaultContent();
 

--- a/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
+++ b/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
@@ -50,8 +50,8 @@ public class AxeExampleUnitTest {
   private static final String shadowErrorPage = "src/test/resources/html/shadow-error.html";
   private static final String includeExcludePage = "src/test/resources/html/include-exclude.html";
   private static final String normalPage = "src/test/resources/html/normal.html";
-  private static final String nestedIframe = "src/test/resources/html/nested-iframes.html";
-  private static final String nestedFrame = "src/test/resources/html/nested-frames.html";
+  private static final String nestedIframePage = "src/test/resources/html/nested-iframes.html";
+  private static final String nestedFramePage = "src/test/resources/html/nested-frames.html";
 
   /**
    * Instantiate the WebDriver and navigate to the test site
@@ -117,7 +117,7 @@ public class AxeExampleUnitTest {
    */
   @Test
   public void testInjectsIntoNestedIframes() throws IOException, OperationNotSupportedException {
-    this.webDriver.get("file:///" + new File(nestedIframe).getAbsolutePath());
+    this.webDriver.get("file:///" + new File(nestedIframePage).getAbsolutePath());
     Results result = new AxeBuilder().withOnlyRules(Arrays.asList("frame-title")).analyze(webDriver);
     List<Rule> violations = result.getViolations();
     Assert.assertEquals("'frame-title' passed", 1, violations.size());
@@ -139,7 +139,7 @@ public class AxeExampleUnitTest {
    */
   @Test
   public void testInjectsIntoNestedFrames() throws IOException, OperationNotSupportedException {
-    this.webDriver.get("file:///" + new File(nestedFrame).getAbsolutePath());
+    this.webDriver.get("file:///" + new File(nestedFramePage).getAbsolutePath());
     Results result = new AxeBuilder().withOnlyRules(Arrays.asList("frame-title")).analyze(webDriver);
     List<Rule> violations = result.getViolations();
     Assert.assertEquals("'frame-title' passed", 1, violations.size());

--- a/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
+++ b/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
@@ -50,6 +50,8 @@ public class AxeExampleUnitTest {
   private static final String shadowErrorPage = "src/test/resources/html/shadow-error.html";
   private static final String includeExcludePage = "src/test/resources/html/include-exclude.html";
   private static final String normalPage = "src/test/resources/html/normal.html";
+  private static final String nestedIframe = "src/test/resources/html/nested-iframes.html";
+  private static final String nestedFrame = "src/test/resources/html/nested-frames.html";
 
   /**
    * Instantiate the WebDriver and navigate to the test site
@@ -106,6 +108,50 @@ public class AxeExampleUnitTest {
 
     File jsonFile = new File("src/test/java/results/testAccessibilityWithSkipFrames.json");
     File txtFile = new File("src/test/java/results/testAccessibilityWithSkipFrames.txt");
+    Assert.assertTrue("Json file was not deleted.", jsonFile.delete());
+    Assert.assertTrue("Txt file was not deleted.", txtFile.delete());
+  }
+
+  /**
+   * Test with nested iframes
+   */
+  @Test
+  public void testInjectsIntoNestedIframes() throws IOException, OperationNotSupportedException {
+    this.webDriver.get("file:///" + new File(nestedIframe).getAbsolutePath());
+    Results result = new AxeBuilder().withOnlyRules(Arrays.asList("frame-title")).analyze(webDriver);
+    List<Rule> violations = result.getViolations();
+    Assert.assertEquals("'frame-title' passed", 1, violations.size());
+    Assert.assertEquals("3 nodes found", 3, violations.get(0).getNodes().size());
+    AxeReporter.writeResultsToJsonFile("src/test/java/results/testInjectsIntoNestedIframes", result);
+
+    Assert.assertTrue(getReadableAxeResults(ResultType.Violations.getKey(), webDriver, violations));
+    AxeReporter.writeResultsToTextFile("src/test/java/results/testInjectsIntoNestedIframes",
+        AxeReporter.getAxeResultString());
+
+    File jsonFile = new File("src/test/java/results/testInjectsIntoNestedIframes.json");
+    File txtFile = new File("src/test/java/results/testInjectsIntoNestedIframes.txt");
+    Assert.assertTrue("Json file was not deleted.", jsonFile.delete());
+    Assert.assertTrue("Txt file was not deleted.", txtFile.delete());
+  }
+
+  /**
+   * Test with nested frames
+   */
+  @Test
+  public void testInjectsIntoNestedFrames() throws IOException, OperationNotSupportedException {
+    this.webDriver.get("file:///" + new File(nestedFrame).getAbsolutePath());
+    Results result = new AxeBuilder().withOnlyRules(Arrays.asList("frame-title")).analyze(webDriver);
+    List<Rule> violations = result.getViolations();
+    Assert.assertEquals("'frame-title' passed", 1, violations.size());
+    Assert.assertEquals("3 nodes found", 3, violations.get(0).getNodes().size());
+    AxeReporter.writeResultsToJsonFile("src/test/java/results/testInjectsIntoNestedFrames", result);
+
+    Assert.assertTrue(getReadableAxeResults(ResultType.Violations.getKey(), webDriver, violations));
+    AxeReporter.writeResultsToTextFile("src/test/java/results/testInjectsIntoNestedFrames",
+        AxeReporter.getAxeResultString());
+
+    File jsonFile = new File("src/test/java/results/testInjectsIntoNestedFrames.json");
+    File txtFile = new File("src/test/java/results/testInjectsIntoNestedFrames.txt");
     Assert.assertTrue("Json file was not deleted.", jsonFile.delete());
     Assert.assertTrue("Txt file was not deleted.", txtFile.delete());
   }

--- a/src/test/resources/html/frames/bar.html
+++ b/src/test/resources/html/frames/bar.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Bar</title>
+  </head>
+  <frameset>
+    <frame src="baz.html">
+  </frameset>
+</html>

--- a/src/test/resources/html/frames/baz.html
+++ b/src/test/resources/html/frames/baz.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Baz</title>
+  </head>
+  <body>
+    <h1>Baz</h1>
+  </body>
+</html>

--- a/src/test/resources/html/frames/foo.html
+++ b/src/test/resources/html/frames/foo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Foo</title>
+  </head>
+  <frameset>
+    <frame src="bar.html">
+  </frameset>
+</html>

--- a/src/test/resources/html/iframes/bar.html
+++ b/src/test/resources/html/iframes/bar.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Bar</title>
+  </head>
+  <body>
+    <h1>Bar</h1>
+    <iframe src="baz.html"></iframe>
+  </body>
+</html>

--- a/src/test/resources/html/iframes/baz.html
+++ b/src/test/resources/html/iframes/baz.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Baz</title>
+  </head>
+  <body>
+    <h1>Baz</h1>
+  </body>
+</html>

--- a/src/test/resources/html/iframes/foo.html
+++ b/src/test/resources/html/iframes/foo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Foo</title>
+  </head>
+  <body>
+    <h1>Foo</h1>
+    <iframe src="bar.html"></iframe>
+  </body>
+</html>

--- a/src/test/resources/html/nested-frames.html
+++ b/src/test/resources/html/nested-frames.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nested Frames</title>
+  </head>
+  <frameset>
+    <frame src="frames/foo.html">
+  </frameset>
+</html>

--- a/src/test/resources/html/nested-iframes.html
+++ b/src/test/resources/html/nested-iframes.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nested Frames</title>
+  </head>
+  <body>
+    <h1>This page has nested frames!</h1>
+    <br /><br /><br />
+    <iframe src="iframes/foo.html"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
Fixed to recursively find `<frame>`  and inject a script into them, not only `<iframe>`.

`<frame>` is deprecated in HTML5, but sometimes use in bad examples when teach modern & accessible coding.
ex) https://barrierfree.nict.go.jp/accessibility/whatsacs/sample/level0/index.html

Thanks!

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
