### PR TITLE
perf: Optimize iframe recursion

### DIFF
--- a/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
+++ b/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
@@ -126,12 +126,19 @@ public final class WebDriverInjectorExtensions {
     List<WebElement> frames = driver.findElements(By.xpath(".//*[local-name()='frame' or local-name()='iframe']"));
 
     for (WebElement frame : frames) {
+      try {
         driver.switchTo().frame(frame);
         js.executeScript(script);
 
         injectIntoFrames(driver, script);
 
         driver.switchTo().parentFrame();
+      } catch (Exception e) {
+        // Ignore all errors except those caused by the injected javascript itself
+        if (e instanceof JavascriptException) {
+          throw e;
+        }
+      }
     }
   }
 
@@ -147,12 +154,19 @@ public final class WebDriverInjectorExtensions {
     List<WebElement> frames = driver.findElements(By.xpath(".//*[local-name()='frame' or local-name()='iframe']"));
 
     for (WebElement frame : frames) {
-      driver.switchTo().frame(frame);
-      js.executeScript(script);
+      try {
+        driver.switchTo().frame(frame);
+        js.executeScript(script);
 
-      injectIntoFramesAsync(driver, script);
+        injectIntoFramesAsync(driver, script);
 
-      driver.switchTo().parentFrame();
+        driver.switchTo().parentFrame();
+      } catch (Exception e) {
+        // Ignore all errors except those caused by the injected javascript itself
+        if (e instanceof JavascriptException) {
+          throw e;
+        }
+      }
     }
   }
 }

--- a/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
+++ b/src/main/java/com/deque/html/axecore/extensions/WebDriverInjectorExtensions.java
@@ -79,14 +79,7 @@ public final class WebDriverInjectorExtensions {
     driver.switchTo().defaultContent();
     js.executeScript(script);
     if (!disableIframeTesting) {
-      try {
-        injectIntoFrames(driver, script);
-      } catch (Exception e) {
-        // Ignore all errors except those caused by the injected javascript itself
-        if (e instanceof JavascriptException) {
-          throw e;
-        }
-      }
+      injectIntoFrames(driver, script);
     }
   }
 
@@ -103,14 +96,7 @@ public final class WebDriverInjectorExtensions {
     js.executeAsyncScript(script);
 
     if (!disableIframeTesting) {
-      try {
-        injectIntoFramesAsync(driver, script);
-      } catch (Exception e) {
-        // Ignore all errors except those caused by the injected javascript itself
-        if (e instanceof JavascriptException) {
-          throw e;
-        }
-      }
+      injectIntoFramesAsync(driver, script);
     }
   }
 


### PR DESCRIPTION
We can use `driver.switchTo().parentFrame()` for better recursion rather than tracking parents explicitly and having to switch to `defaultContext()` multiple times.

Running default analysis on a page with 3 i-frames including 1 nested i-frame (e.g., http://watir.com/examples/nested_iframes.html) takes [47 commands](https://app.saucelabs.com/tests/07d35a9b701a4ada87dfcb27f832f7f7) currently, this code drops it to [34 commands](https://app.saucelabs.com/tests/1e9e2438794540deb5870b57d59a9744).

Note, I was able to drop this further to [23 commands](https://app.saucelabs.com/tests/e18435a5223c443981a92531de8c46fe) by implementing script injection from an Array, but this code is a little hacky, and I'd want to discuss it more before making a real PR from it: https://github.com/titusfortner/axe-core-maven-html/commit/8e294ef2f6bbc07824aa086bc5a6fec92aa18c01