### PR TITLE
feat: new submodule: `utilities` to contain all the commonly used JSON mapped Java classes

### DIFF
--- a/.circleci/snapshot.py
+++ b/.circleci/snapshot.py
@@ -39,7 +39,7 @@ def make_version_snapshot(pom_dir):
     tree.write(pom_path, xml_declaration = True, encoding = 'utf-8', method = 'xml')
     print 'Added %s to version' % ss
 
-pom_dirs = ['', 'selenium', 'playwright']
+pom_dirs = ['', 'selenium', 'playwright', 'utilities']
 
 for dir in pom_dirs:
     make_version_snapshot(dir)

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -1,27 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.deque.html.axe-core</groupId>
-    <artifactId>virtual-superpackage</artifactId>
-    <version>4.4.0</version>
-    <packaging>pom</packaging>
+    <parent>
+        <groupId>com.deque.html.axe-core</groupId>
+        <artifactId>virtual-superpackage</artifactId>
+        <version>4.4.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
+    <name>Axe-core maven utilities</name>
+    <description>axe-core-maven-html utility classes used in all packages</description>
     <url>https://github.com/dequelabs/axe-core-maven-html</url>
 
-    <modules>
-        <module>selenium</module>
-        <module>playwright</module>
-        <module>utilities</module>
-    </modules>
-
-    <licenses>
-        <license>
-            <name>Mozilla Public License, Version 2.0</name>
-            <url>https://www.mozilla.org/MPL/2.0/</url>
-        </license>
-    </licenses>
+    <artifactId>dequeutilites</artifactId>
+    <version>4.4.0</version>
+    <packaging>jar</packaging>
 
     <distributionManagement>
         <repository>
@@ -34,26 +30,24 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <developers>
-        <developer>
-            <name>Deque Labs</name>
-            <email>helpdesk@deque.com</email>
-            <organization>Deque Labs</organization>
-            <organizationUrl>http://www.deque.com</organizationUrl>
-        </developer>
-    </developers>
-
     <scm>
         <connection>scm:git:git@github.com:dequelabs/axe-core-maven-html.git</connection>
         <developerConnection>scm:git:git@github.com:dequelabs/axe-core-maven-html.git</developerConnection>
         <url>https://github.com/dequelabs/axe-core-maven-html</url>
     </scm>
 
+
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <licenses>
+        <license>
+            <name>Mozilla Public License, Version 2.0</name>
+            <url>https://www.mozilla.org/MPL/2.0/</url>
+        </license>
+    </licenses>
 
     <profiles>
         <profile>
@@ -63,7 +57,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -82,14 +76,6 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M3</version>
-                        <configuration>
-                            <runOrder>alphabetical</runOrder>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>
@@ -99,10 +85,19 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
-                </plugin>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/utilities/src/main/java/com/deque/html/axecore/args/AxeRuleOptions.java
+++ b/utilities/src/main/java/com/deque/html/axecore/args/AxeRuleOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.args;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Used as part of AxeRunOptions to configure rules. */
+public class AxeRuleOptions {
+  /** Denotes if the rule has to be enabled for scanning. */
+  private Boolean enabled;
+
+  /**
+   * gets the enabled property.
+   *
+   * @return if the property is enabled.
+   */
+  @JsonProperty(value = "enabled")
+  public Boolean getEnabled() {
+    return this.enabled;
+  }
+
+  /**
+   * sets the enabled value.
+   *
+   * @param newEnabled value to be set
+   */
+  @JsonProperty(value = "enabled")
+  public void setEnabled(final Boolean newEnabled) {
+    this.enabled = newEnabled;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/args/AxeRules.java
+++ b/utilities/src/main/java/com/deque/html/axecore/args/AxeRules.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.args;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/** Axe rules JSON configurator. */
+public class AxeRules {
+  /** Denotes if the rule has to be enabled for scanning. */
+  private Map<String, AxeRuleOptions> rules;
+
+  /**
+   * gets the rules.
+   *
+   * @return a map of rule names and Axe rule options
+   */
+  @JsonProperty("rules")
+  public Map<String, AxeRuleOptions> getRules() {
+    return rules;
+  }
+
+  /**
+   * sets the rules.
+   *
+   * @param value the new values to bes set
+   */
+  @JsonProperty("rules")
+  public void setRules(final Map<String, AxeRuleOptions> value) {
+    this.rules = value;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/args/AxeRunContext.java
+++ b/utilities/src/main/java/com/deque/html/axecore/args/AxeRunContext.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.args;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/** contains context for the Accessibility run scan. */
+public class AxeRunContext {
+  /** list of what to include in the scan. */
+  private List<List<String>> include;
+
+  /** list of what to exclude in the scan. */
+  private List<List<String>> exclude;
+
+  /**
+   * gets a list of included values.
+   *
+   * @return the included values
+   */
+  @JsonProperty(value = "include")
+  public List<List<String>> getInclude() {
+    return this.include;
+  }
+
+  /**
+   * sets the included values.
+   *
+   * @param newInclude new values to be included
+   */
+  @JsonProperty(value = "include")
+  public void setInclude(final List<String> newInclude) {
+    if (include == null) {
+      this.include = new ArrayList<>();
+    }
+    this.include.add(newInclude);
+  }
+
+  /**
+   * gets the exclude list.
+   *
+   * @return a list of excluded elements
+   */
+  @JsonProperty(value = "exclude")
+  public List<List<String>> getExclude() {
+    if (exclude == null) {
+      this.exclude = new ArrayList<List<String>>();
+    }
+    return this.exclude;
+  }
+
+  /**
+   * sets the exclude list.
+   *
+   * @param newExclude a new list of strings to be set
+   */
+  @JsonProperty(value = "exclude")
+  public void setExclude(final List<String> newExclude) {
+    if (exclude == null) {
+      this.exclude = new ArrayList<List<String>>();
+    }
+    this.exclude.add(newExclude);
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/args/AxeRunOnlyOptions.java
+++ b/utilities/src/main/java/com/deque/html/axecore/args/AxeRunOnlyOptions.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is
+ * subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.args;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Class object for Axe Run Only Options. */
+public class AxeRunOnlyOptions {
+  /** Specifies the context for run only option. (can be "rule" or "tag"). */
+  private String type;
+
+  /** Has rules / tags that needs to be executed. (context is based on Type). */
+  private List<String> values;
+
+  /**
+   * gets the type.
+   *
+   * @return the type
+   */
+  @JsonProperty(value = "type")
+  public String getType() {
+    return this.type;
+  }
+
+  /**
+   * sets the type.
+   *
+   * @param newType the new type to be set
+   */
+  @JsonProperty(value = "type")
+  public void setType(final String newType) {
+    this.type = newType;
+  }
+
+  /**
+   * gets the value of the Axe Run Only Options.
+   *
+   * @return a list of strings with the value
+   */
+  @JsonProperty(value = "values")
+  public List<String> getValues() {
+    return this.values;
+  }
+
+  /**
+   * sets the values of the Axe Run only options.
+   *
+   * @param newValues the new values to be set
+   */
+  @JsonProperty(value = "values")
+  public void setValues(final List<String> newValues) {
+    this.values = newValues;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/args/AxeRunOptions.java
+++ b/utilities/src/main/java/com/deque/html/axecore/args/AxeRunOptions.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2020 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.args;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+import java.util.Map;
+
+/** Run configuration data that is passed to axe for scanning the web page. */
+@JsonPropertyOrder({
+  "rules",
+  "absolutePaths",
+  "iframes",
+  "restoreScroll",
+  "frameWaitTime",
+  "runOnly"
+})
+@JsonIgnoreProperties(value = "xpath")
+public class AxeRunOptions {
+  /** Allow customizing a rule's properties (including { enable: false }). */
+  private Map<String, AxeRuleOptions> rules;
+
+  /** Limit which rules are executed, based on names or tags. */
+  private AxeRunOnlyOptions runOnly;
+
+  /**
+   * Limit which result types are processed and aggregated. An approach you can take to reducing the
+   * time is use the resultTypes option. For eg, when set to [ResultTypes.Violations], scan results
+   * will only have the full details of the violations array and will only have one instance of each
+   * of the inapplicable, incomplete and pass arrays for each rule that has at least one of those
+   * entries. This will reduce the amount of computation that axe-core does for the unique
+   * selectors.
+   */
+  private List<String> resultTypes;
+
+  /** Use absolute paths when creating element selectors. */
+  private Boolean absolutePaths;
+
+  /** How long (in milliseconds) axe waits for a response from embedded frames before timing out. */
+  private Integer frameWaitTimeInMilliseconds;
+
+  /** Tell axe to run inside iFrames. */
+  private Boolean iframe;
+
+  /** Scrolls elements back to the state before scan started. */
+  private Boolean restoreScroll;
+
+  /** Returns xpath selectors for elements. */
+  private Boolean xpath;
+
+  /**
+   * gets the run only property.
+   *
+   * @return the run only property
+   */
+  @JsonProperty(value = "runOnly")
+  public AxeRunOnlyOptions getRunOnly() {
+    return this.runOnly;
+  }
+
+  /**
+   * sets the run only property.
+   *
+   * @param newRunOnly the new run only to be set
+   */
+  @JsonProperty(value = "runOnly")
+  public void setRunOnly(final AxeRunOnlyOptions newRunOnly) {
+    this.runOnly = newRunOnly;
+  }
+
+  /**
+   * gets the rules.
+   *
+   * @return the rules
+   */
+  @JsonProperty(value = "rules")
+  public Map<String, AxeRuleOptions> getRules() {
+    return this.rules;
+  }
+
+  /**
+   * sets the rules.
+   *
+   * @param newRules the new rules to be set
+   */
+  @JsonProperty(value = "rules")
+  public void setRules(final Map<String, AxeRuleOptions> newRules) {
+    this.rules = newRules;
+  }
+
+  /**
+   * gets the result types.
+   *
+   * @return the result types
+   */
+  @JsonProperty(value = "resultTypes")
+  public List<String> getResultTypes() {
+    return this.resultTypes;
+  }
+
+  /**
+   * sets the result types.
+   *
+   * @param newResultTypes the new result types to be set
+   */
+  @JsonProperty(value = "resultTypes")
+  public void setResultTypes(final List<String> newResultTypes) {
+    this.resultTypes = newResultTypes;
+  }
+
+  /**
+   * gets the xpath.
+   *
+   * @return the xpath
+   */
+  @JsonProperty(value = "xpath")
+  public boolean getXPath() {
+    return this.xpath;
+  }
+
+  /**
+   * sets the xpath.
+   *
+   * @param newXPath the new xpath to be set
+   */
+  @JsonProperty(value = "xpath")
+  public void setXPath(final Boolean newXPath) {
+    this.xpath = newXPath;
+  }
+
+  /**
+   * gets if there are absolute paths.
+   *
+   * @return if there are absolute paths
+   */
+  @JsonProperty(value = "absolutePaths")
+  public Boolean getAbsolutePaths() {
+    return this.absolutePaths;
+  }
+
+  /**
+   * sets if there are absolute paths.
+   *
+   * @param newAbsolutePath the bool to be set if there are absolute paths
+   */
+  @JsonProperty(value = "absolutePaths")
+  public void setAbsolutePaths(final Boolean newAbsolutePath) {
+    this.absolutePaths = newAbsolutePath;
+  }
+
+  /**
+   * gets if there are iFrames.
+   *
+   * @return if there are iFrames
+   */
+  @JsonProperty(value = "iFrames")
+  public Boolean getIFrames() {
+    return this.iframe;
+  }
+
+  /**
+   * sets if there are iFrames.
+   *
+   * @param newIFrames the bool to be set if there are iFrames
+   */
+  @JsonProperty(value = "iFrames")
+  public void setIFrames(final Boolean newIFrames) {
+    this.iframe = newIFrames;
+  }
+
+  /**
+   * gets if there is a restore scroll.
+   *
+   * @return the bool if there is a restore scroll
+   */
+  public Boolean getRestoreScroll() {
+    return this.restoreScroll;
+  }
+
+  /**
+   * sets the restore scroll.
+   *
+   * @param newRestoreScroll bool if there is a restore scroll
+   */
+  @JsonProperty(value = "restoreScroll")
+  public void setRestoreScroll(final Boolean newRestoreScroll) {
+    this.restoreScroll = newRestoreScroll;
+  }
+
+  /**
+   * gets the frame wait time milliseconds.
+   *
+   * @return the frame wait time
+   */
+  @JsonProperty(value = "frameWaitTime")
+  public Integer getFrameWaitTimeInMilliseconds() {
+    return this.frameWaitTimeInMilliseconds;
+  }
+
+  /**
+   * sets the frame wait time milliseconds.
+   *
+   * @param newFrameWaitTime the new frame wait time to be set
+   */
+  @JsonProperty(value = "frameWaitTime")
+  public void setFrameWaitTimeInMilliseconds(final Integer newFrameWaitTime) {
+    this.frameWaitTimeInMilliseconds = newFrameWaitTime;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/AxeResults.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/AxeResults.java
@@ -106,9 +106,12 @@ public class AxeResults {
   }
 
   public boolean violationFree() {
-    if (this.violations == null) {
+    // If the violations list has not been initialized, there
+    // are no violations. This prevents a `NullPointerException` when
+    // calling this method if `.isErrored() == true`.
+    if (violations == null) {
       return true;
     }
-    return this.violations.size() == 0;
+    return violations.size() == 0;
   }
 }

--- a/utilities/src/main/java/com/deque/html/axecore/results/AxeResults.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/AxeResults.java
@@ -1,0 +1,114 @@
+package com.deque.html.axecore.results;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AxeResults {
+  private ToolOptions toolOptions;
+  private TestEngine testEngine;
+  private TestEnvironment testEnvironment;
+  private TestRunner testRunner;
+  private String url;
+  private String timestamp;
+  private List<Rule> passes;
+  private List<Rule> violations;
+  private List<Rule> incomplete;
+  private List<Rule> inapplicable;
+  private AxeRuntimeException errorObject;
+
+  public AxeResults() {}
+
+  public boolean isErrored() {
+    return this.errorObject != null;
+  }
+
+  public void setErrorMessage(Exception errorObject) {
+    this.errorObject = new AxeRuntimeException(errorObject);
+  }
+
+  public String getErrorMessage() {
+    return this.errorObject == null ? null : this.errorObject.getCause().toString();
+  }
+
+  @JsonIgnore
+  public AxeRuntimeException getError() {
+    return this.isErrored() ? this.errorObject : null;
+  }
+
+  public String getUrl() {
+    return this.url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getTimestamp() {
+    return this.timestamp;
+  }
+
+  public void setTimestamp(String timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public TestEngine getTestEngine() {
+    return this.testEngine;
+  }
+
+  public void setTestEngine(TestEngine testEngine) {
+    this.testEngine = testEngine;
+  }
+
+  public TestEnvironment getTestEnvironment() {
+    return this.testEnvironment;
+  }
+
+  public TestRunner getTestRunner() {
+    return this.testRunner;
+  }
+
+  public ToolOptions getToolOptions() {
+    return this.toolOptions;
+  }
+
+  public List<Rule> getPasses() {
+    return this.passes;
+  }
+
+  public void setPasses(List<Rule> passes) {
+    this.passes = passes;
+  }
+
+  public List<Rule> getViolations() {
+    return this.violations;
+  }
+
+  public void setViolations(List<Rule> violations) {
+    this.violations = violations;
+  }
+
+  public List<Rule> getInapplicable() {
+    return this.inapplicable;
+  }
+
+  public void setInapplicable(List<Rule> inapplicable) {
+    this.inapplicable = inapplicable;
+  }
+
+  public List<Rule> getIncomplete() {
+    return this.incomplete;
+  }
+
+  public void setIncomplete(List<Rule> incomplete) {
+    this.incomplete = incomplete;
+  }
+
+  public boolean violationFree() {
+    if (this.violations == null) {
+      return true;
+    }
+    return this.violations.size() == 0;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/AxeRuntimeException.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/AxeRuntimeException.java
@@ -1,0 +1,10 @@
+package com.deque.html.axecore.results;
+
+/** AxeRuntimeException represents an error returned from `axe.run()`. */
+public class AxeRuntimeException extends RuntimeException {
+  private static final long serialVersionUID = -123456789087654L;
+
+  public AxeRuntimeException(Exception cause) {
+    super("Error when running axe", cause);
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/Check.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Check.java
@@ -1,0 +1,52 @@
+package com.deque.html.axecore.results;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Check {
+  private String id;
+  private String impact;
+  private String message;
+  private Object data;
+  private List<Node> relatedNodes = new ArrayList<Node>();
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getImpact() {
+    return impact;
+  }
+
+  public void setImpact(final String impact) {
+    this.impact = impact;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+
+  public Object getData() {
+    return data;
+  }
+
+  public void setData(final Object data) {
+    this.data = data;
+  }
+
+  public List<Node> getRelatedNodes() {
+    return relatedNodes;
+  }
+
+  public void setRelatedNodes(final List<Node> relatedNodes) {
+    this.relatedNodes = relatedNodes;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/CheckedNode.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/CheckedNode.java
@@ -1,0 +1,52 @@
+package com.deque.html.axecore.results;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CheckedNode extends Node {
+  private String impact;
+  private List<Check> any = new ArrayList<Check>();
+  private List<Check> all = new ArrayList<Check>();
+  private List<Check> none = new ArrayList<Check>();
+  private String failureSummary;
+
+  public String getImpact() {
+    return impact;
+  }
+
+  public void setImpact(final String impact) {
+    this.impact = impact;
+  }
+
+  public List<Check> getAny() {
+    return any;
+  }
+
+  public void setAny(final List<Check> any) {
+    this.any = any;
+  }
+
+  public List<Check> getAll() {
+    return all;
+  }
+
+  public void setAll(final List<Check> all) {
+    this.all = all;
+  }
+
+  public List<Check> getNone() {
+    return none;
+  }
+
+  public void setNone(final List<Check> none) {
+    this.none = none;
+  }
+
+  public String getFailureSummary() {
+    return failureSummary;
+  }
+
+  public void setFailureSummary(final String failureSummary) {
+    this.failureSummary = failureSummary;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/FrameContext.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/FrameContext.java
@@ -1,0 +1,22 @@
+package com.deque.html.axecore.results;
+
+public class FrameContext {
+  private Object frameSelector;
+  private Object frameContext;
+
+  public Object getFrameSelector() {
+    return frameSelector;
+  }
+
+  public void setFrameSelector(final Object selector) {
+    this.frameSelector = selector;
+  }
+
+  public Object getFrameContext() {
+    return frameContext;
+  }
+
+  public void setFrameContext(final Object context) {
+    this.frameContext = context;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/Node.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Node.java
@@ -1,0 +1,22 @@
+package com.deque.html.axecore.results;
+
+public class Node {
+  private String html;
+  private Object target;
+
+  public String getHtml() {
+    return html;
+  }
+
+  public void setHtml(final String html) {
+    this.html = html;
+  }
+
+  public Object getTarget() {
+    return target;
+  }
+
+  public void setTarget(final Object target) {
+    this.target = target;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/Platform.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Platform.java
@@ -1,0 +1,44 @@
+package com.deque.html.axecore.results;
+
+public class Platform {
+  private String userAgent;
+  private String testMachine;
+
+  public String getUserAgent() {
+    return userAgent;
+  }
+
+  public void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  public String getTestMachine() {
+    return testMachine;
+  }
+
+  public void setTestMachine(String testMachine) {
+    this.testMachine = testMachine;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Platform)) return false;
+
+    Platform platform = (Platform) o;
+
+    if (getUserAgent() != null
+        ? !getUserAgent().equals(platform.getUserAgent())
+        : platform.getUserAgent() != null) return false;
+    return getTestMachine() != null
+        ? getTestMachine().equals(platform.getTestMachine())
+        : platform.getTestMachine() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getUserAgent() != null ? getUserAgent().hashCode() : 0;
+    result = 31 * result + (getTestMachine() != null ? getTestMachine().hashCode() : 0);
+    return result;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/Results.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Results.java
@@ -1,0 +1,123 @@
+package com.deque.html.axecore.results;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Results {
+  private ToolOptions toolOptions;
+  private TestEngine testEngine;
+  private TestEnvironment testEnvironment;
+  private TestRunner testRunner;
+  private String url;
+  private String timestamp;
+  private List<Rule> passes;
+  private List<Rule> violations;
+  private List<Rule> incomplete;
+  private List<Rule> inapplicable;
+  // The error message from `axe.run()`
+  private AxeRuntimeException errorObject;
+
+  public boolean isErrored() {
+    return errorObject != null;
+  }
+
+  public void setErrorMessage(final Exception errorObject) {
+    this.errorObject = new AxeRuntimeException(errorObject);
+  }
+
+  public String getErrorMessage() {
+    if (errorObject == null) {
+      return null;
+    }
+    return errorObject.getCause().toString();
+  }
+
+  @JsonIgnore
+  public AxeRuntimeException getError() {
+    if (this.isErrored()) {
+      return errorObject;
+    }
+
+    return null;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(final String url) {
+    this.url = url;
+  }
+
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(final String timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public TestEngine getTestEngine() {
+    return testEngine;
+  }
+
+  public void setTestEngine(final TestEngine testEngine) {
+    this.testEngine = testEngine;
+  }
+
+  public TestEnvironment getTestEnvironment() {
+    return testEnvironment;
+  }
+
+  public TestRunner getTestRunner() {
+    return testRunner;
+  }
+
+  public ToolOptions getToolOptions() {
+    return toolOptions;
+  }
+
+  public List<Rule> getPasses() {
+    return passes;
+  }
+
+  public void setPasses(final List<Rule> passes) {
+    this.passes = passes;
+  }
+
+  public List<Rule> getViolations() {
+    return violations;
+  }
+
+  public void setViolations(final List<Rule> violations) {
+    this.violations = violations;
+  }
+
+  public List<Rule> getInapplicable() {
+    return inapplicable;
+  }
+
+  public void setInapplicable(final List<Rule> inapplicable) {
+    this.inapplicable = inapplicable;
+  }
+
+  public List<Rule> getIncomplete() {
+    return incomplete;
+  }
+
+  public void setIncomplete(final List<Rule> incomplete) {
+    this.incomplete = incomplete;
+  }
+
+  public boolean violationFree() {
+    // If the violations list has not been initialized, there
+    // are no violations. This prevents a `NullPointerException` when
+    // calling this method if `.isErrored() == true`.
+    if (violations == null) {
+      return true;
+    }
+    return violations.size() == 0;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/Rule.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Rule.java
@@ -1,0 +1,121 @@
+package com.deque.html.axecore.results;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Rule {
+  private String id;
+  private String description;
+  private String help;
+  private String helpUrl;
+  private String impact;
+  private List<String> tags = new ArrayList<String>();
+  private List<CheckedNode> nodes = new ArrayList<CheckedNode>();
+  private String url;
+  private String createdDate;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public String getHelp() {
+    return help;
+  }
+
+  public void setHelp(final String help) {
+    this.help = help;
+  }
+
+  public String getHelpUrl() {
+    return helpUrl;
+  }
+
+  public void setHelpUrl(final String helpUrl) {
+    this.helpUrl = helpUrl;
+  }
+
+  public String getImpact() {
+    return impact;
+  }
+
+  public void setImpact(final String impact) {
+    this.impact = impact != null ? impact : "";
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(final List<String> tags) {
+    this.tags = tags;
+  }
+
+  public List<CheckedNode> getNodes() {
+    return nodes;
+  }
+
+  public void setNodes(final List<CheckedNode> nodes) {
+    this.nodes = nodes;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getCreatedDate() {
+    return createdDate;
+  }
+
+  public void setCreatedDate(String createdDate) {
+    this.createdDate = createdDate;
+  }
+
+  @Override
+  public String toString() {
+    return "Rule{"
+        + "id='"
+        + id
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", help='"
+        + help
+        + '\''
+        + ", helpUrl='"
+        + helpUrl
+        + '\''
+        + ", impact='"
+        + impact
+        + '\''
+        + ", tags="
+        + tags
+        + ", nodes="
+        + nodes
+        + ", url='"
+        + url
+        + '\''
+        + ", createdDate='"
+        + createdDate
+        + '\''
+        + '}';
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/TestEngine.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/TestEngine.java
@@ -1,0 +1,18 @@
+package com.deque.html.axecore.results;
+
+public class TestEngine {
+  private String name;
+  private String version;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/TestEnvironment.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/TestEnvironment.java
@@ -1,0 +1,29 @@
+package com.deque.html.axecore.results;
+
+public class TestEnvironment {
+  private String userAgent;
+  private int windowWidth;
+  private int windowHeight;
+  private double orientationAngle;
+  private String orientationType;
+
+  public String getUserAgent() {
+    return userAgent;
+  }
+
+  public int getWindowHeight() {
+    return windowHeight;
+  }
+
+  public int getwindowWidth() {
+    return windowWidth;
+  }
+
+  public double getOrientationAngle() {
+    return orientationAngle;
+  }
+
+  public String getOrientationType() {
+    return orientationType;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/TestResults.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/TestResults.java
@@ -1,0 +1,105 @@
+package com.deque.html.axecore.results;
+
+public class TestResults {
+  private String type;
+  private String name;
+  private String id;
+  private Platform platform = new Platform();
+  private TestSubject testSubject = new TestSubject();
+  private Results findings;
+  private String endTime;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Platform getPlatform() {
+    return platform;
+  }
+
+  public void setPlatform(Platform platform) {
+    this.platform = platform;
+  }
+
+  public TestSubject getTestSubject() {
+    return testSubject;
+  }
+
+  public void setTestSubject(TestSubject testSubject) {
+    this.testSubject = testSubject;
+  }
+
+  public Results getFindings() {
+    return findings;
+  }
+
+  public void setFindings(Results findings) {
+    this.findings = findings;
+  }
+
+  public String getEndTime() {
+    return endTime;
+  }
+
+  public void setEndTime(String endTime) {
+    this.endTime = endTime;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TestResults)) return false;
+
+    TestResults that = (TestResults) o;
+
+    if (getType() != null ? !getType().equals(that.getType()) : that.getType() != null)
+      return false;
+    if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null)
+      return false;
+    if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+    if (getPlatform() != null
+        ? !getPlatform().equals(that.getPlatform())
+        : that.getPlatform() != null) return false;
+    if (getTestSubject() != null
+        ? !getTestSubject().equals(that.getTestSubject())
+        : that.getTestSubject() != null) return false;
+    if (getFindings() != null
+        ? !getFindings().equals(that.getFindings())
+        : that.getFindings() != null) return false;
+    return getEndTime() != null
+        ? getEndTime().equals(that.getEndTime())
+        : that.getEndTime() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getType() != null ? getType().hashCode() : 0;
+    result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+    result = 31 * result + (getId() != null ? getId().hashCode() : 0);
+    result = 31 * result + (getPlatform() != null ? getPlatform().hashCode() : 0);
+    result = 31 * result + (getTestSubject() != null ? getTestSubject().hashCode() : 0);
+    result = 31 * result + (getFindings() != null ? getFindings().hashCode() : 0);
+    result = 31 * result + (getEndTime() != null ? getEndTime().hashCode() : 0);
+    return result;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/TestRunner.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/TestRunner.java
@@ -1,0 +1,9 @@
+package com.deque.html.axecore.results;
+
+public class TestRunner {
+  private String name;
+
+  public String getName() {
+    return name;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/TestSubject.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/TestSubject.java
@@ -1,0 +1,64 @@
+package com.deque.html.axecore.results;
+
+public class TestSubject {
+  private String fileName;
+  private String state;
+  private String lineNum;
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public void setState(String state) {
+    this.state = state;
+  }
+
+  public String getLineNum() {
+    return lineNum;
+  }
+
+  public void setLineNum(String lineNum) {
+    this.lineNum = lineNum;
+  }
+
+  public String getFormattedLineNum() {
+    if (null != getLineNum()) {
+      return "Line number: " + getLineNum();
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof TestSubject)) return false;
+
+    TestSubject that = (TestSubject) o;
+
+    if (getFileName() != null
+        ? !getFileName().equals(that.getFileName())
+        : that.getFileName() != null) return false;
+    if (getState() != null ? !getState().equals(that.getState()) : that.getState() != null)
+      return false;
+    return getLineNum() != null
+        ? getLineNum().equals(that.getLineNum())
+        : that.getLineNum() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getFileName() != null ? getFileName().hashCode() : 0;
+    result = 31 * result + (getState() != null ? getState().hashCode() : 0);
+    result = 31 * result + (getLineNum() != null ? getLineNum().hashCode() : 0);
+    return result;
+  }
+}

--- a/utilities/src/main/java/com/deque/html/axecore/results/ToolOptions.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/ToolOptions.java
@@ -1,0 +1,41 @@
+package com.deque.html.axecore.results;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ToolOptions {
+  private String reporter;
+  private Object rules;
+  private Map<String, Object> properties;
+
+  public String getReporter() {
+    return reporter;
+  }
+
+  public void setReporter(String reporter) {
+    this.reporter = reporter;
+  }
+
+  public Object getRules() {
+    return rules;
+  }
+
+  public void setRules(Object rules) {
+    this.rules = rules;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  @JsonAnySetter
+  public void setProperty(String name, Object value) {
+    if (properties == null) {
+      properties = new HashMap<String, Object>();
+    }
+    properties.put(name, value);
+  }
+}


### PR DESCRIPTION
Moves all of the commonly used JSON mapping classes in Selenium and Playwright into its own package `utilities`. 

We will then import this package as dependency for each current (and new) integration(s) to save creating again for each. 

Part of issue: https://github.com/dequelabs/axe-core-maven-html/issues/207
