### PR TITLE
fix: add missing plugins to superpackage, playwright and utilities required for publishing

### DIFF
--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -204,6 +204,39 @@
                         </configuration>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
     <version>4.4.0</version>
     <packaging>pom</packaging>
 
+    <name>Axe-core-maven-html Superpackage</name>
+    <description>axe-core-maven-html superpackage containing; selenium, playwright, and, utilities</description>
     <url>https://github.com/dequelabs/axe-core-maven-html</url>
 
     <modules>
@@ -90,6 +92,26 @@
                         </configuration>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>
@@ -99,7 +121,7 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
-                </plugin>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -76,6 +76,39 @@
                         </configuration>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>


### PR DESCRIPTION
We had to manually release via CI due to `playwright` and `utilities` missing the required plugins for GPG signing and generating sources for publishing:

```sh
[ERROR] Nexus Staging Rules Failure Report
[ERROR] ==================================
[ERROR] 
[ERROR]   Rule "pom-staging" failures
[ERROR]     * Invalid POM: /com/deque/html/axe-core/virtual-superpackage/4.4.1/virtual-superpackage-4.4.1.pom: Project name missing, Project description missing
[ERROR]   Rule "signature-staging" failures
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/virtual-superpackage/4.4.1/virtual-superpackage-4.4.1.pom.asc' does not exist for 'virtual-superpackage-4.4.1.pom'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/playwright/4.4.1/playwright-4.4.1.jar.asc' does not exist for 'playwright-4.4.1.jar'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/playwright/4.4.1/playwright-4.4.1-javadoc.jar.asc' does not exist for 'playwright-4.4.1-javadoc.jar'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/playwright/4.4.1/playwright-4.4.1.pom.asc' does not exist for 'playwright-4.4.1.pom'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/playwright/4.4.1/playwright-4.4.1-with-dependencies.jar.asc' does not exist for 'playwright-4.4.1-with-dependencies.jar'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/dequeutilites/4.4.1/dequeutilites-4.4.1-javadoc.jar.asc' does not exist for 'dequeutilites-4.4.1-javadoc.jar'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/dequeutilites/4.4.1/dequeutilites-4.4.1.pom.asc' does not exist for 'dequeutilites-4.4.1.pom'.
[ERROR]     * Missing Signature: '/com/deque/html/axe-core/dequeutilites/4.4.1/dequeutilites-4.4.1.jar.asc' does not exist for 'dequeutilites-4.4.1.jar'.
[ERROR]   Rule "sources-staging" failures
[ERROR]     * Missing: no sources jar found in folder '/com/deque/html/axe-core/playwright/4.4.1'
[ERROR]     * Missing: no sources jar found in folder '/com/deque/html/axe-core/dequeutilites/4.4.1'
```
source: [CI failure job](https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/515/workflows/004653c3-2b11-4702-9859-f0e3b1ce9865/jobs/1169?invite=true#step-106-1282).


