### PR TITLE
Update README.md

### DIFF
--- a/selenium/README.md
+++ b/selenium/README.md
@@ -49,5 +49,5 @@ and run the `analyze` method to get results.
 - `withOptions` takes an options object to be passed to the `axe.run` call.
 - `withTags` limits rules run to those that match specified tags.
 - `withOnlyRules` limites rules run to those specified.
-- `disabledRules` disables rules.
+- `disableRules` disables rules.
 - `analyze` executes axe with any configuration you have previously defined. If you want to test one or more `WebElement`s, you may pass them into `analyze` instead of using `include` and `exclude`.


### PR DESCRIPTION
Corrected `disabledRules` to `disableRules` to match the method name, here: https://github.com/dequelabs/axe-core-maven-html/blob/a51db3c1215b769fbafeb769c8b83ecc19dd147c/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java#L336

Issue: 
`disabledRules` is not the correct name of the method cited in the README.