### PR TITLE
fix: improve result toString implementation to be more actionable

### DIFF
--- a/playwright/src/test/java/PlaywrightJavaTest.java
+++ b/playwright/src/test/java/PlaywrightJavaTest.java
@@ -831,4 +831,23 @@ public class PlaywrightJavaTest {
         Arrays.asList(Arrays.asList("#shadow-root", "#shadow-frame"), "input"));
     assertEquals(checkedNodes.get(2).getTarget(), Arrays.asList("#slotted-frame", "input"));
   }
+
+  /** Test that violations.toString() includes enough information to be actionable */
+  @Test
+  public void testViolationToStringActionability()
+      throws IOException, OperationNotSupportedException {
+    page.navigate(server + "context.html");
+    AxeBuilder axeBuilder = new AxeBuilder(page);
+    AxeResults axeResults = axeBuilder.analyze();
+
+    List<Rule> violations = axeResults.getViolations();
+    String violationsString = violations.toString();
+
+    Assert.assertTrue(violationsString.contains("[img]"));
+    Assert.assertTrue(violationsString.contains("<img src=\"\">"));
+    Assert.assertTrue(violationsString.contains("image-alt"));
+    Assert.assertTrue(violationsString.contains("critical"));
+    Assert.assertTrue(violationsString.contains("Element does not have an alt attribute"));
+    Assert.assertTrue(violationsString.contains("WCAG 1.1.1"));
+  }
 }

--- a/playwright/src/test/java/PlaywrightJavaTest.java
+++ b/playwright/src/test/java/PlaywrightJavaTest.java
@@ -836,18 +836,18 @@ public class PlaywrightJavaTest {
   @Test
   public void testViolationToStringActionability()
       throws IOException, OperationNotSupportedException {
-    page.navigate(server + "context.html");
+    page.navigate(server + "index.html");
     AxeBuilder axeBuilder = new AxeBuilder(page);
     AxeResults axeResults = axeBuilder.analyze();
 
     List<Rule> violations = axeResults.getViolations();
     String violationsString = violations.toString();
 
-    Assert.assertTrue(violationsString.contains("[img]"));
-    Assert.assertTrue(violationsString.contains("<img src=\"\">"));
-    Assert.assertTrue(violationsString.contains("image-alt"));
-    Assert.assertTrue(violationsString.contains("critical"));
-    Assert.assertTrue(violationsString.contains("Element does not have an alt attribute"));
-    Assert.assertTrue(violationsString.contains("WCAG 1.1.1"));
+    assertTrue(violationsString.contains("[html]"));
+    assertTrue(violationsString.contains("<html lang=\"en\">"));
+    assertTrue(violationsString.contains("landmark-one-main"));
+    assertTrue(violationsString.contains("moderate"));
+    assertTrue(violationsString.contains("Document does not have a main landmark"));
+    assertTrue(violationsString.contains("best-practice"));
   }
 }

--- a/playwright/src/test/java/PlaywrightJavaTest.java
+++ b/playwright/src/test/java/PlaywrightJavaTest.java
@@ -843,11 +843,18 @@ public class PlaywrightJavaTest {
     List<Rule> violations = axeResults.getViolations();
     String violationsString = violations.toString();
 
-    assertTrue(violationsString.contains("[html]"));
-    assertTrue(violationsString.contains("<html lang=\"en\">"));
-    assertTrue(violationsString.contains("landmark-one-main"));
-    assertTrue(violationsString.contains("moderate"));
-    assertTrue(violationsString.contains("Document does not have a main landmark"));
-    assertTrue(violationsString.contains("best-practice"));
+    List<String> expectedSubstrings = Arrays.asList(
+      "landmark-one-main",
+      "best-practice",
+      "moderate",
+      "[html]",
+      "<html lang=\"en\">",
+      "Document does not have a main landmark");
+    
+    for (String expectedSubstring : expectedSubstrings) {
+      assertTrue(
+       String.format("axeResults.violations.toString() should contain substring \"%s\", found \"%s\"", expectedSubstring, violationsString),
+       violationsString.contains(expectedSubstring));
+    }
   }
 }

--- a/selenium/src/main/java/com/deque/html/axecore/results/Check.java
+++ b/selenium/src/main/java/com/deque/html/axecore/results/Check.java
@@ -49,4 +49,25 @@ public class Check {
   public void setRelatedNodes(final List<Node> relatedNodes) {
     this.relatedNodes = relatedNodes;
   }
+
+  @Override
+  public String toString() {
+    return "CheckedNode{"
+        + "id='"
+        + id
+        + '\''
+        + ", impact='"
+        + impact
+        + '\''
+        + ", message='"
+        + message
+        + '\''
+        + ", data='"
+        + data
+        + '\''
+        + ", relatedNodes='"
+        + relatedNodes
+        + '\''
+        + '}';
+  }
 }

--- a/selenium/src/main/java/com/deque/html/axecore/results/CheckedNode.java
+++ b/selenium/src/main/java/com/deque/html/axecore/results/CheckedNode.java
@@ -49,4 +49,31 @@ public class CheckedNode extends Node {
   public void setFailureSummary(final String failureSummary) {
     this.failureSummary = failureSummary;
   }
+
+  @Override
+  public String toString() {
+    return "CheckedNode{"
+        + "target='"
+        + getTarget()
+        + '\''
+        + ", html='"
+        + getHtml()
+        + '\''
+        + ", impact='"
+        + impact
+        + '\''
+        + ", failureSummary='"
+        + failureSummary
+        + '\''
+        + ", any='"
+        + any
+        + '\''
+        + ", all='"
+        + all
+        + '\''
+        + ", none='"
+        + none
+        + '\''
+        + '}';
+  }
 }

--- a/selenium/src/main/java/com/deque/html/axecore/results/Node.java
+++ b/selenium/src/main/java/com/deque/html/axecore/results/Node.java
@@ -19,4 +19,16 @@ public class Node {
   public void setTarget(final Object target) {
     this.target = target;
   }
+
+  @Override
+  public String toString() {
+    return "Node{"
+        + "target='"
+        + target
+        + '\''
+        + ", html='"
+        + html
+        + '\''
+        + '}';
+  }
 }

--- a/selenium/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
+++ b/selenium/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
@@ -417,4 +417,22 @@ public class AxeExampleUnitTest {
     Assert.assertTrue("Json file was not deleted.", jsonFile.delete());
     Assert.assertTrue("Txt file was not deleted.", txtFile.delete());
   }
+
+  /** Test that violations.toString() includes enough information to be actionable */
+  @Test
+  public void testViolationToStringActionability()
+      throws IOException, OperationNotSupportedException {
+    this.webDriver.get("file:///" + new File(includeExcludePage).getAbsolutePath());
+    Results result = new AxeBuilder().analyze(webDriver);
+
+    List<Rule> violations = result.getViolations();
+    String violationsString = violations.toString();
+
+    Assert.assertTrue(violationsString.contains("[img]"));
+    Assert.assertTrue(violationsString.contains("<img src=\"\">"));
+    Assert.assertTrue(violationsString.contains("image-alt"));
+    Assert.assertTrue(violationsString.contains("critical"));
+    Assert.assertTrue(violationsString.contains("Element does not have an alt attribute"));
+    Assert.assertTrue(violationsString.contains("WCAG 1.1.1"));
+  }
 }

--- a/selenium/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
+++ b/selenium/src/test/java/com/deque/html/axecore/selenium/AxeExampleUnitTest.java
@@ -422,17 +422,24 @@ public class AxeExampleUnitTest {
   @Test
   public void testViolationToStringActionability()
       throws IOException, OperationNotSupportedException {
-    this.webDriver.get("file:///" + new File(includeExcludePage).getAbsolutePath());
+    this.webDriver.get("file:///" + new File(violationPage).getAbsolutePath());
     Results result = new AxeBuilder().analyze(webDriver);
 
     List<Rule> violations = result.getViolations();
     String violationsString = violations.toString();
 
-    Assert.assertTrue(violationsString.contains("[img]"));
-    Assert.assertTrue(violationsString.contains("<img src=\"\">"));
-    Assert.assertTrue(violationsString.contains("image-alt"));
-    Assert.assertTrue(violationsString.contains("critical"));
-    Assert.assertTrue(violationsString.contains("Element does not have an alt attribute"));
-    Assert.assertTrue(violationsString.contains("WCAG 1.1.1"));
+    List<String> expectedSubstrings = Arrays.asList(
+        "image-alt",
+        "wcag111",
+        "critical",
+        "[img]",
+        "<img src=\"\">",
+        "Element does not have an alt attribute");
+      
+    for (String expectedSubstring : expectedSubstrings) {
+    Assert.assertTrue(
+        String.format("axeResults.violations.toString() should contain substring \"%s\", found \"%s\"", expectedSubstring, violationsString),
+        violationsString.contains(expectedSubstring));
+    }
   }
 }

--- a/utilities/src/main/java/com/deque/html/axecore/results/Check.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Check.java
@@ -49,4 +49,25 @@ public class Check {
   public void setRelatedNodes(final List<Node> relatedNodes) {
     this.relatedNodes = relatedNodes;
   }
+
+  @Override
+  public String toString() {
+    return "CheckedNode{"
+        + "id='"
+        + id
+        + '\''
+        + ", impact='"
+        + impact
+        + '\''
+        + ", message='"
+        + message
+        + '\''
+        + ", data='"
+        + data
+        + '\''
+        + ", relatedNodes='"
+        + relatedNodes
+        + '\''
+        + '}';
+  }
 }

--- a/utilities/src/main/java/com/deque/html/axecore/results/CheckedNode.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/CheckedNode.java
@@ -49,4 +49,31 @@ public class CheckedNode extends Node {
   public void setFailureSummary(final String failureSummary) {
     this.failureSummary = failureSummary;
   }
+
+  @Override
+  public String toString() {
+    return "CheckedNode{"
+        + "target='"
+        + getTarget()
+        + '\''
+        + ", html='"
+        + getHtml()
+        + '\''
+        + ", impact='"
+        + impact
+        + '\''
+        + ", failureSummary='"
+        + failureSummary
+        + '\''
+        + ", any='"
+        + any
+        + '\''
+        + ", all='"
+        + all
+        + '\''
+        + ", none='"
+        + none
+        + '\''
+        + '}';
+  }
 }

--- a/utilities/src/main/java/com/deque/html/axecore/results/Node.java
+++ b/utilities/src/main/java/com/deque/html/axecore/results/Node.java
@@ -19,4 +19,16 @@ public class Node {
   public void setTarget(final Object target) {
     this.target = target;
   }
+
+  @Override
+  public String toString() {
+    return "Node{"
+        + "target='"
+        + target
+        + '\''
+        + ", html='"
+        + html
+        + '\''
+        + '}';
+  }
 }


### PR DESCRIPTION
Issue: Currently, the `toString` methods for `Check`s, `CheckedNode`s, and `Node`s in Selenium and Playwright don't provide a lot of information to the user during accessibility testing. This PR overrides the `toString` methods in these instances, similar to how it's done in [Rule.java](https://github.com/dequelabs/axe-core-maven-html/blob/5fe065d85e01a0c6b0f0a252554941cd01c62f42/selenium/src/main/java/com/deque/html/axecore/results/Rule.java#L92), to provide more actionable output to the user.