### PR TITLE
tests: fix Playwright tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}
       - restore_cache:
           key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
-      - run: mvn install -DskipTests
+      - run: mvn clean install -DskipTests
       - save_cache:
           key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}
           paths:

--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -254,13 +254,6 @@
     </profiles>
 
     <dependencies>
-
-        <dependency>
-            <groupId>com.deque.html.axe-core</groupId>
-            <artifactId>dequeutilites</artifactId>
-            <version>4.4.1</version>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/com.microsoft.playwright/playwright -->
         <dependency>
             <groupId>com.microsoft.playwright</groupId>
@@ -316,6 +309,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.deque.html.axe-core</groupId>
+            <artifactId>dequeutilites</artifactId>
+            <version>4.4.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR fixes two things, one we want to `clean install` at the top level (not required, but in case there are any cached changes, we clean install to grab any new changes). Second, the dependency for `utilities` default scope for each dependency defaults to `compile` but this may not be the case within CI, so this fixes the scoping to compile before the tests are ran