### PR TITLE
ci: ensure pre-commit hook works in release script

### DIFF
--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -14,7 +14,7 @@ fi
 cd ..
 
 # For reference: https://github.com/clibs/clib/blob/master/scripts/pre-commit-hook.sh#L3-L10
-function format_and_restage_file {
+format_and_restage_file () {
   local file="$1"
   if [ -f "$file" ]; then
     java -jar .cache/google-java-format-1.7-all-deps.jar --replace $file


### PR DESCRIPTION
This PR ensures the pre-commit hook is able to run in the `create-release` workflow: 

Tested: https://github.com/dequelabs/axe-core-maven-html/actions/runs/3406974918/jobs/5666150831 

Useful resource: https://stackoverflow.com/a/12469057 

Closes Issue: https://github.com/dequelabs/axe-core-maven-html/issues/265
