### PR TITLE
ci: update cache version due to missing dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,16 +14,16 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: mvn clean install -DskipTests
       - save_cache:
-          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
           paths:
             - ~/.m2
       - save_cache:
-          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
           paths:
             - node_modules
             - selenium/node_modules
@@ -34,9 +34,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}
       - run: sudo apt update && sudo apt install python2
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
@@ -60,9 +60,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
@@ -82,9 +82,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: sudo apt update && sudo apt install python
@@ -96,9 +96,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: .circleci/publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,17 +14,16 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: mvn clean install -DskipTests
       - save_cache:
-          key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
           paths:
             - ~/.m2
-      - run: npm install      
       - save_cache:
-          key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
           paths:
             - node_modules
             - selenium/node_modules
@@ -35,9 +34,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}
+          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}
       - run: sudo apt update && sudo apt install python2
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
@@ -61,9 +60,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
@@ -83,9 +82,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: sudo apt update && sudo apt install python
@@ -97,9 +96,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
+          key: v3-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: v3-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: .circleci/publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           key: v2-mvn-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
           paths:
             - ~/.m2
+      - run: npm install      
       - save_cache:
           key: v2-npm-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
           paths:

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axe-core-maven-html-playwright",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axe-core-maven-html-playwright",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MPL",
       "dependencies": {
         "axe-core": "^4.5.2"
@@ -41,16 +41,16 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
-      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
+      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axe-test-fixtures": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#43682ed5262b8c36db68bdc70526e2820c40480a",
+      "resolved": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#464337d0fb0f3f051dbb8483ca30c559d91b1746",
       "dev": true,
       "license": "MPL-2.0"
     },
@@ -303,10 +303,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -474,12 +477,12 @@
       }
     },
     "axe-core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
-      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
+      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw=="
     },
     "axe-test-fixtures": {
-      "version": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#43682ed5262b8c36db68bdc70526e2820c40480a",
+      "version": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#464337d0fb0f3f051dbb8483ca30c559d91b1746",
       "dev": true,
       "from": "axe-test-fixtures@github:dequelabs/axe-test-fixtures"
     },
@@ -661,9 +664,9 @@
       "dev": true
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mkdirp": {

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
-      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "engines": {
         "node": ">=4"
       }
@@ -477,9 +477,9 @@
       }
     },
     "axe-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
-      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw=="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
     },
     "axe-test-fixtures": {
       "version": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#464337d0fb0f3f051dbb8483ca30c559d91b1746",

--- a/selenium/package-lock.json
+++ b/selenium/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
-      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "engines": {
         "node": ">=4"
       }
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "axe-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
-      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw=="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
     },
     "axe-test-fixtures": {
       "version": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#464337d0fb0f3f051dbb8483ca30c559d91b1746",

--- a/selenium/package-lock.json
+++ b/selenium/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axe-core-maven-html-selenium",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axe-core-maven-html-selenium",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "UNLICENSED",
       "dependencies": {
         "axe-core": "^4.5.2"
@@ -16,28 +16,28 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
-      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
+      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axe-test-fixtures": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#ddc6e711051f0f8b834b7c01f1f056b04cf39e70",
+      "resolved": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#464337d0fb0f3f051dbb8483ca30c559d91b1746",
       "dev": true,
       "license": "MPL-2.0"
     }
   },
   "dependencies": {
     "axe-core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
-      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
+      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw=="
     },
     "axe-test-fixtures": {
-      "version": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#ddc6e711051f0f8b834b7c01f1f056b04cf39e70",
+      "version": "git+ssh://git@github.com/dequelabs/axe-test-fixtures.git#464337d0fb0f3f051dbb8483ca30c559d91b1746",
       "dev": true,
       "from": "axe-test-fixtures@github:dequelabs/axe-test-fixtures"
     }


### PR DESCRIPTION
This PR fixes an issue with out-of-sync package locks (see: https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/719/workflows/71b2ed2d-211a-40d6-b9c4-e14f8149b8b7/jobs/1809). 

Updated cache version to generate a new cache from new node_modules