### PR TITLE
ci: separate dependencies job into npm and do not cache maven

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,6 @@ defaults: &defaults
   working_directory: ~/axe-core-maven-html
 
 jobs:
-  # fetch and cache maven dependencies
-  dependencies_maven:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
-      - run: mvn clean install -DskipTests
-      - save_cache:
-          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
-          paths:
-            - ~/.m2
-
   # fetch and cache npm dependencies
   dependencies_npm:
     <<: *defaults
@@ -44,8 +31,6 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
-      - restore_cache:
           key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: sudo apt update && sudo apt install python2
       - browser-tools/install-chrome
@@ -62,6 +47,7 @@ jobs:
           background: true
 
       - run: sleep 5 # sleep to allow the server some time to boot
+      - run: mvn clean install -DskipTests
       # run only selenium tests in this job
       - run: mvn test -pl selenium
 
@@ -69,8 +55,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
           key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - browser-tools/install-chrome
@@ -84,6 +68,7 @@ jobs:
           name: Start test fixture server
           command: cd playwright && npm start
           background: true
+      - run: mvn clean install -DskipTests
       # run only playwright tests in this job
       - run: mvn test -q -pl playwright
 
@@ -92,9 +77,8 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
-      - restore_cache:
           key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+      - run: mvn clean install -DskipTests
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: sudo apt update && sudo apt install python
@@ -106,9 +90,8 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
-      - restore_cache:
           key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+      - run: mvn clean install -DskipTests
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: .circleci/publish.sh
@@ -131,20 +114,16 @@ workflows:
   build_and_test:
     jobs:
       - dependencies_npm
-      - dependencies_maven
       - selenium:
           requires:
             - dependencies_npm
-            - dependencies_maven
       - playwright:
           requires:
             - dependencies_npm
-            - dependencies_maven
       - snapshot_release:
           context: html-tools
           requires:
             - dependencies_npm
-            - dependencies_maven
             - selenium
             - playwright
           filters:
@@ -154,7 +133,6 @@ workflows:
           context: html-tools
           requires:
             - dependencies_npm
-            - dependencies_maven
             - selenium
             - playwright
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-        key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: npm ci
-      - run: npm --prefix=playwright ci
       - run: npm --prefix=selenium ci
+      - run: npm --prefix=playwright ci
       - save_cache:
           key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
           command: |
             google-chrome --version
             chromedriver --version
+      - run: mvn clean install -DskipTests
       - run:
           command: node selenium/src/test/resources/test-app.js
           background: true
@@ -47,7 +48,6 @@ jobs:
           background: true
 
       - run: sleep 5 # sleep to allow the server some time to boot
-      - run: mvn clean install -DskipTests
       # run only selenium tests in this job
       - run: mvn test -pl selenium
 
@@ -63,12 +63,12 @@ jobs:
           command: |
             google-chrome --version
             chromedriver --version
+      - run: mvn clean install -DskipTests
       # start the test fixture server
       - run:
           name: Start test fixture server
           command: cd playwright && npm start
           background: true
-      - run: mvn clean install -DskipTests
       # run only playwright tests in this job
       - run: mvn test -q -pl playwright
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,29 @@ defaults: &defaults
   working_directory: ~/axe-core-maven-html
 
 jobs:
-  dependencies:
+  # fetch and cache maven dependencies
+  dependencies_maven:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
           key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
-      - restore_cache:
-          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: mvn clean install -DskipTests
       - save_cache:
           key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
           paths:
             - ~/.m2
+
+  # fetch and cache npm dependencies
+  dependencies_npm:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+        key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
+      - run: npm ci
+      - run: npm --prefix=playwright ci
+      - run: npm --prefix=selenium ci
       - save_cache:
           key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
           paths:
@@ -36,7 +46,7 @@ jobs:
       - restore_cache:
           key: mvn-v1-deps-{{ checksum "pom.xml" }}-{{ checksum "selenium/pom.xml" }}-{{ checksum "playwright/pom.xml" }}-{{ checksum "utilities/pom.xml" }}
       - restore_cache:
-          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: sudo apt update && sudo apt install python2
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
@@ -120,17 +130,21 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - dependencies
+      - dependencies_npm
+      - dependencies_maven
       - selenium:
           requires:
-            - dependencies
+            - dependencies_npm
+            - dependencies_maven
       - playwright:
           requires:
-            - dependencies
+            - dependencies_npm
+            - dependencies_maven
       - snapshot_release:
           context: html-tools
           requires:
-            - dependencies
+            - dependencies_npm
+            - dependencies_maven
             - selenium
             - playwright
           filters:
@@ -139,7 +153,8 @@ workflows:
       - release:
           context: html-tools
           requires:
-            - dependencies
+            - dependencies_npm
+            - dependencies_maven
             - selenium
             - playwright
           filters:


### PR DESCRIPTION
Remove maven dependency caching because it is causing it to pull the previous version: https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/728/workflows/774bb7f7-9da9-493b-b5fa-64fd01fffa2e/jobs/1837?invite=true#step-108-44. 