### PR TITLE
ci: ensure java-doc creation runs in snapshot release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ workflows:
             - playwright
           filters:
             branches:
-              only: fix/snapshot-release
+              only: develop
       - release:
           context: html-tools
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ workflows:
             - playwright
           filters:
             branches:
-              only: develop
+              only: fix/snapshot-release
       - release:
           context: html-tools
           requires:

--- a/playwright/src/main/java/com/deque/html/axecore/playwright/AxeBuilder.java
+++ b/playwright/src/main/java/com/deque/html/axecore/playwright/AxeBuilder.java
@@ -67,7 +67,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by supplying a single object to include
    *
-   * @param selector - List of Strings, FromFrames, FromShadowDom object
+   * @param selector List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -82,7 +82,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by combining Shadow DOM and Frame Context to include
    *
-   * @param selector - provide a list nested selectors
+   * @param selector provide a list nested selectors
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -97,7 +97,7 @@ public class AxeBuilder {
   /**
    * Limit frame testing with the use of `fromFrames`.
    *
-   * @param fromFrames - List of specific sections within a frame to include
+   * @param fromFrames List of specific sections within a frame to include
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
@@ -112,7 +112,7 @@ public class AxeBuilder {
   /**
    * Limit shadow DOM testing with the use of `excludeFromShadowDom`.
    *
-   * @param fromShadowDom - List of shadow DOM host element(s) to include
+   * @param fromShadowDom List of shadow DOM host element(s) to include
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom
@@ -151,7 +151,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by supplying a single object to exclude
    *
-   * @param selector - List of Strings, FromFrames, FromShadowDom object
+   * @param selector List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -166,7 +166,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by combining Shadow DOM and Frame Context to exclude
    *
-   * @param selector - provide a list nested selectors
+   * @param selector Provide a list nested selectors
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -181,7 +181,7 @@ public class AxeBuilder {
   /**
    * Limit frame testing with the use of `fromFrames`.
    *
-   * @param fromFrames - List of specific sections within a frame to exclude
+   * @param fromFrames List of specific sections within a frame to exclude
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
@@ -196,7 +196,7 @@ public class AxeBuilder {
   /**
    * Limit shadow DOM testing with the use of `excludeFromShadowDom`.
    *
-   * @param fromShadowDom - List of shadow DOM host element(s) to exclude
+   * @param fromShadowDom List of shadow DOM host element(s) to exclude
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom

--- a/playwright/src/main/java/com/deque/html/axecore/playwright/AxeBuilder.java
+++ b/playwright/src/main/java/com/deque/html/axecore/playwright/AxeBuilder.java
@@ -11,11 +11,13 @@ import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Frame;
 import com.microsoft.playwright.Page;
+
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
+
 import org.apache.commons.io.IOUtils;
 
 /** Chainable class: AxeBuilder used to customize and analyze using axe-core */
@@ -68,8 +70,8 @@ public class AxeBuilder {
    * @param selector - List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context </a>
    */
   public AxeBuilder include(Object selector) {
     this.context.setInclude(selector);
@@ -83,8 +85,8 @@ public class AxeBuilder {
    * @param selector - provide a list nested selectors
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context</a>
    */
   public AxeBuilder include(Object... selector) {
     this.context.setInclude(selector);
@@ -98,7 +100,7 @@ public class AxeBuilder {
    * @param fromFrames - List of specific sections within a frame to include
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
    *     </a>
    */
   public AxeBuilder include(FromFrames fromFrames) {
@@ -113,7 +115,7 @@ public class AxeBuilder {
    * @param fromShadowDom - List of shadow DOM host element(s) to include
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom
    *     </a>
    */
   public AxeBuilder include(FromShadowDom fromShadowDom) {
@@ -152,8 +154,8 @@ public class AxeBuilder {
    * @param selector - List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context </a>
    */
   public AxeBuilder exclude(Object selector) {
     this.context.setExclude(selector);
@@ -167,8 +169,8 @@ public class AxeBuilder {
    * @param selector - provide a list nested selectors
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context </a>
    */
   public AxeBuilder exclude(Object... selector) {
     this.context.setExclude(selector);
@@ -182,7 +184,7 @@ public class AxeBuilder {
    * @param fromFrames - List of specific sections within a frame to exclude
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
    *     </a>
    */
   public AxeBuilder exclude(FromFrames fromFrames) {
@@ -197,7 +199,7 @@ public class AxeBuilder {
    * @param fromShadowDom - List of shadow DOM host element(s) to exclude
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom
    *     </a>
    */
   public AxeBuilder exclude(FromShadowDom fromShadowDom) {
@@ -423,12 +425,12 @@ public class AxeBuilder {
   /**
    * *
    *
-   * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/master/doc/run-partial.md#axeutilsgetframecontextscontext-framecontext>axe-core
-   *     frameContexts</a>
    * @param frame current iframe
    * @param context current context
    * @return returns array of frameContexts
+   * @see <a
+   *     href="https://github.com/dequelabs/axe-core/blob/master/doc/run-partial.md#axeutilsgetframecontextscontext-framecontext>axe-core
+   *     frameContexts</a>
    */
   private Object getFrameContexts(Frame frame, String context) {
     return frame.evaluate(

--- a/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
+++ b/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
@@ -383,8 +383,8 @@ public class AxeBuilder {
    * @param selector - List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context </a>
    */
   public AxeBuilder include(Object selector) {
     this.runContext.setInclude(selector);
@@ -398,8 +398,8 @@ public class AxeBuilder {
    * @param selector - provide a list nested selectors
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context</a>
    */
   public AxeBuilder include(Object... selector) {
     this.runContext.setInclude(selector);
@@ -413,7 +413,7 @@ public class AxeBuilder {
    * @param fromFrames - List of specific sections within a frame to include
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
    *     </a>
    */
   public AxeBuilder include(FromFrames fromFrames) {
@@ -428,7 +428,7 @@ public class AxeBuilder {
    * @param fromShadowDom - List of shadow DOM host element(s) to include
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom
    *     </a>
    */
   public AxeBuilder include(FromShadowDom fromShadowDom) {
@@ -471,8 +471,8 @@ public class AxeBuilder {
    * @param selector - List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context </a>
    */
   public AxeBuilder exclude(Object selector) {
     this.runContext.setExclude(selector);
@@ -486,8 +486,8 @@ public class AxeBuilder {
    * @param selector - provide a list nested selectors
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context"
-   *     </a>
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
+   *     shadow DOM and frame context </a>
    */
   public AxeBuilder exclude(Object... selector) {
     this.runContext.setExclude(selector);
@@ -501,7 +501,7 @@ public class AxeBuilder {
    * @param fromFrames - List of specific sections within a frame to exclude
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
    *     </a>
    */
   public AxeBuilder exclude(FromFrames fromFrames) {
@@ -516,7 +516,7 @@ public class AxeBuilder {
    * @param fromShadowDom - List of shadow DOM host element(s) to exclude
    * @return this
    * @see <a
-   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing
+   *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom
    *     </a>
    */
   public AxeBuilder exclude(FromShadowDom fromShadowDom) {

--- a/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
+++ b/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
@@ -380,7 +380,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by supplying a single object to include
    *
-   * @param selector - List of Strings, FromFrames, FromShadowDom object
+   * @param selector List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -395,7 +395,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by combining Shadow DOM and Frame Context to include
    *
-   * @param selector - provide a list nested selectors
+   * @param selector Provide a list nested selectors
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -410,7 +410,7 @@ public class AxeBuilder {
   /**
    * Limit frame testing with the use of `fromFrames`.
    *
-   * @param fromFrames - List of specific sections within a frame to include
+   * @param fromFrames List of specific sections within a frame to include
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
@@ -425,7 +425,7 @@ public class AxeBuilder {
   /**
    * Limit shadow DOM testing with the use of `excludeFromShadowDom`.
    *
-   * @param fromShadowDom - List of shadow DOM host element(s) to include
+   * @param fromShadowDom List of shadow DOM host element(s) to include
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom
@@ -468,7 +468,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by supplying a single object to exclude
    *
-   * @param selector - List of Strings, FromFrames, FromShadowDom object
+   * @param selector List of Strings, FromFrames, FromShadowDom object
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -483,7 +483,7 @@ public class AxeBuilder {
   /**
    * Build more complex selectors by combining Shadow DOM and Frame Context to exclude
    *
-   * @param selector - provide a list nested selectors
+   * @param selector Provide a list nested selectors
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#combine-shadow-dom-and-frame-context">Combine
@@ -498,7 +498,7 @@ public class AxeBuilder {
   /**
    * Limit frame testing with the use of `fromFrames`.
    *
-   * @param fromFrames - List of specific sections within a frame to exclude
+   * @param fromFrames List of specific sections within a frame to exclude
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-frame-testing">FromFrames
@@ -513,7 +513,7 @@ public class AxeBuilder {
   /**
    * Limit shadow DOM testing with the use of `excludeFromShadowDom`.
    *
-   * @param fromShadowDom - List of shadow DOM host element(s) to exclude
+   * @param fromShadowDom List of shadow DOM host element(s) to exclude
    * @return this
    * @see <a
    *     href="https://github.com/dequelabs/axe-core/blob/develop/doc/context.md#limit-shadow-dom-testing">FromShadowDom


### PR DESCRIPTION
This PR fixes the snapshot build within CI when attempting to publish snapshot as the javadoc syntax was incorrect 

See for reference: https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/740/workflows/4fc61439-a0ec-4044-8091-3a6551a2e31e/jobs/1878?invite=true#step-108-1000 

<details>
<summary>Rendered Docs</summary>
<img width="508" alt="image" src="https://user-images.githubusercontent.com/41127686/210402693-2dc1192a-5a97-4e0b-ae53-7bd560b2b015.png">
</details>
