### PR TITLE
docs: remove confusing usage example for `include` and `exlcude`

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -127,12 +127,6 @@ CSS selectors to include during analysis
 
 ```java
 new AxeBuilder(page)
-        .include(Collections.singletonList(".some-class"))
-        .include(Collections.singletonList(".some-other-class"));
-
-// OR
-
-new AxeBuilder(page)
         .include(".some-class")
         .include(".some-other-class");
 ```
@@ -155,12 +149,6 @@ new AxeBuilder(page)
 CSS selectors to exclude during analysis
 
 ```java
-new AxeBuilder(page)
-        .exclude(Collections.singletonList(".some-class"))
-        .exclude(Collections.singletonList(".some-other-class"));
-
-// OR
-
 new AxeBuilder(page)
         .exclude(".some-class")
         .exclude(".some-other-class");

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -106,12 +106,6 @@ CSS selectors to include during analysis
 
 ```java
 new AxeBuilder()
-        .include(Collections.singletonList(".some-class"))
-        .include(Collections.singletonList(".some-other-class"));
-
-// OR
-
-        new AxeBuilder()
         .include(".some-class")
         .include(".some-other-class");
 ```
@@ -135,12 +129,6 @@ CSS selectors to exclude during analysis
 
 ```java
 new AxeBuilder()
-        .exclude(Collections.singletonList(".some-class"))
-        .exclude(Collections.singletonList(".some-other-class"));
-
-// OR
-
-        new AxeBuilder()
         .exclude(".some-class")
         .exclude(".some-other-class");
 


### PR DESCRIPTION
Remove confusing usage for `include` and `exclude` selectors when trying to include/exclude multiple elements


For reference: https://axecommunity.slack.com/archives/C01BSF8J6LS/p1679441799898339 - good catch! 