### PR TITLE
ci: ensure `snapshot_release` job publishes canary artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: mvn clean install -DskipTests
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
@@ -138,6 +140,7 @@ workflows:
       - snapshot_release:
           context: html-tools
           requires:
+            - dependencies_npm
             - selenium
             - playwright
             - check_licenses

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
       - run: sudo apt update && sudo apt install python3
-      - run: python .circleci/snapshot.py
+      - run: python3 .circleci/snapshot.py
       - run: .circleci/publish.sh
 
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: npm-v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "selenium/package-lock.json" }}-{{ checksum "playwright/package-lock.json" }}
       - run: mvn clean install -DskipTests
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
@@ -140,7 +138,6 @@ workflows:
       - snapshot_release:
           context: html-tools
           requires:
-            - dependencies_npm
             - selenium
             - playwright
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ workflows:
             - check_licenses
           filters:
             branches:
-              only: ci/fix-snapshot
+              only: develop
       - release:
           context: html-tools
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - run: mvn clean install -DskipTests
       - run: echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import
       - run: echo "default-key 7701193A898A849383D3E8B49F8AFEACBF07F7C4" > ~/.gnupg/gpg.conf
-      - run: sudo apt update && sudo apt install python
+      - run: sudo apt update && sudo apt install python3
       - run: python .circleci/snapshot.py
       - run: .circleci/publish.sh
 
@@ -145,7 +145,7 @@ workflows:
             - playwright
           filters:
             branches:
-              only: develop
+              only: ci/fix-snapshot
       - release:
           context: html-tools
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ workflows:
           requires:
             - selenium
             - playwright
+            - check_licenses
           filters:
             branches:
               only: ci/fix-snapshot
@@ -149,6 +150,7 @@ workflows:
             - dependencies_npm
             - selenium
             - playwright
+            - check_licenses
           filters:
             branches:
               only: master

--- a/.circleci/snapshot.py
+++ b/.circleci/snapshot.py
@@ -37,7 +37,7 @@ def make_version_snapshot(pom_dir):
                 dep_version_node.text = dep_version_node.text + ss
 
     tree.write(pom_path, xml_declaration = True, encoding = 'utf-8', method = 'xml')
-    print 'Added %s to version' % ss
+    print('Added %s to version' % ss)
 
 pom_dirs = ['', 'selenium', 'playwright', 'utilities']
 


### PR DESCRIPTION
This PR ensures our snapshot job runs to create a snapshot artifact once PRs are merged into develop

ref: https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/778/workflows/28e007ce-e856-4032-80da-5e357357c49e/jobs/2056