### PR TITLE
ci: restore the correct cache key for `tests`yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           path: "**/node_modules"
           key: npm-cache-v1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            npm-workspace-cache-${{ runner.os }}-
+            npm-cache-v1-${{ runner.os }}-
       - name: Cache Maven dependencies
         uses: actions/cache@v3
         id: maven-cache
@@ -27,7 +27,7 @@ jobs:
           path: ~/.m2/repository
           key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            maven-cache-v1-${{ runner.os }}-
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
@@ -67,9 +67,9 @@ jobs:
         id: npm-cache
         with:
           path: "**/node_modules"
-          key: npm-workspace-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: npm-cache-v1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            npm-workspace-cache-${{ runner.os }}-
+            npm-cache-v1-${{ runner.os }}-
       - uses: actions/cache@v3
         name: Restore Maven cache
         id: maven-cache
@@ -94,9 +94,9 @@ jobs:
         id: npm-cache
         with:
           path: "**/node_modules"
-          key: npm-workspace-cache-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: npm-cache-v1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            npm-workspace-cache-${{ runner.os }}-
+            npm-cache-v1-${{ runner.os }}-
       - uses: actions/cache@v3
         name: Restore Maven cache
         id: maven-cache


### PR DESCRIPTION
Noticed I did not set the correct cache key when attempting to restore - https://github.com/dequelabs/axe-core-maven-html/actions/runs/5268469465/jobs/9525244607?pr=318#step:3:11