### PR TITLE
chore: update jacoco dep

### DIFF
--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axe-core-maven-html-playwright",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "axe-core-maven-html-playwright",
-      "version": "4.5.1",
+      "version": "4.6.0",
       "license": "MPL",
       "dependencies": {
         "axe-core": "^4.7.0"

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": "dequelabs/axe-core-maven-html",
   "scripts": {
-    "start": "http-server ./node_modules/axe-test-fixtures/fixtures -p 1337"
+    "start": "http-server ./node_modules/axe-test-fixtures/fixtures -p 1337 --silent"
   },
   "dependencies": {
     "axe-core": "^4.7.0"

--- a/playwright/pom.xml
+++ b/playwright/pom.xml
@@ -107,7 +107,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Tried to run the Playwright package but it errored on jacoco. Updating the dependency to support openjdk 20. Also made the http-server log silent.