### PR TITLE
ci: enable manual run of patch release

### DIFF
--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -3,16 +3,25 @@ on:
   schedule:
     # Run every Thurday right before midnight
     - cron: '59 23 * * 4'
+  workflow_dispatch:
 jobs:
   create_patch_release:
     name: Create release
     runs-on: ubuntu-latest
     steps:
+      - name: Determine if we skip cancel checks
+        id: skip-checks
+        shell: bash
+        # Skip checks if we are not a scheduled run
+        run: echo value=$(test ${{ github.event_name }} != schedule && echo true || echo false) >> "$GITHUB_OUTPUT"
+
+
       - name: Create release
         uses: dequelabs/axe-api-team-public/.github/actions/auto-patch-release-v1@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project_token: ${{ secrets.GH_PROJECT_TOKEN }}
+          skip_checks: ${{ steps.skip-checks.outputs.value }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           odd_release: 'true'
           release-command: bash .github/scripts/prepare_release.sh

--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -4,6 +4,7 @@ on:
     # Run every Thurday right before midnight
     - cron: '59 23 * * 4'
   workflow_dispatch:
+  pull_request:
 jobs:
   create_patch_release:
     name: Create release

--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -4,7 +4,6 @@ on:
     # Run every Thurday right before midnight
     - cron: '59 23 * * 4'
   workflow_dispatch:
-  pull_request:
 jobs:
   create_patch_release:
     name: Create release


### PR DESCRIPTION
Test PR: https://github.com/dequelabs/axe-core-maven-html/pull/341
Test Issue: https://github.com/dequelabs/axe-core-maven-html/issues/340
Conditional checks were tested in a personal repo: https://github.com/AdnoC/action-test/actions/workflows/push-and-dispatch.yml

Issue: https://github.com/dequelabs/axe-api-team/issues/342
