### PR TITLE
ci: update `prepare_release.sh` to take optional release level

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -6,11 +6,16 @@ set -e
 releaseLevel="$1"
 
 oldVersion="$(node -pe 'require("./package.json").version')"
-npx standard-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
 
-cd selenium
-npx standard-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
-cd ..
+# TODO: standard-version is now deprecated: https://github.com/dequelabs/axe-core-maven-html/issues/366
+# If no release level is specified, let standard-version handle versioning
+if [ -z "$releaseLevel" ] 
+then
+  npx standard-version --skip.commit=true --skip.changelog=true --skip.tag=true
+else
+  npx standard-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
+fi
+
 newVersion="$(node -pe 'require("./package.json").version')"
 
 


### PR DESCRIPTION
This PR allows the unnamed argument to be optional, if it's not specified it will default standard-version handling version, otherwise it will release as the specified release level.

<details>
<summary>Without specifying a release level</summary>
<img width="1001" alt="image" src="https://github.com/dequelabs/axe-core-maven-html/assets/41127686/d17504bd-da91-4fee-b9ac-589db4972401">

</details>


<details>
<summary>With release level</summary>
<img width="975" alt="image" src="https://github.com/dequelabs/axe-core-maven-html/assets/41127686/9ea4ca5d-263a-48cc-b0a3-a6bec41c67b8">

</details>


Closes: https://github.com/dequelabs/axe-core-maven-html/issues/365
