### PR TITLE
chore: remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "copyfiles": "^2.4.1",
         "del-cli": "^5.1.0",
         "husky": "^8.0.3",
-        "jfrog-cli-go": "^1.54.1",
         "standard-version": "^9.5.0",
         "xml-js": "^1.6.11"
       }
@@ -2159,39 +2158,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "node_modules/jfrog-cli-go": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/jfrog-cli-go/-/jfrog-cli-go-1.54.1.tgz",
-      "integrity": "sha512-UgCOJ1zg9kG+twA7WuMYm/h/5LBQeCzZnS1OQS27ZMMf5AdbOCA/tGOtvyCt0rPvHWaVv5NS+EkuTguXcfEuhg==",
-      "bundleDependencies": [
-        "ms",
-        "debug"
-      ],
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "3.1.0",
-        "ms": "2.0.0"
-      },
-      "bin": {
-        "jfrog": "bin/jfrog"
-      }
-    },
-    "node_modules/jfrog-cli-go/node_modules/debug": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/jfrog-cli-go/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5118,31 +5084,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "jfrog-cli-go": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/jfrog-cli-go/-/jfrog-cli-go-1.54.1.tgz",
-      "integrity": "sha512-UgCOJ1zg9kG+twA7WuMYm/h/5LBQeCzZnS1OQS27ZMMf5AdbOCA/tGOtvyCt0rPvHWaVv5NS+EkuTguXcfEuhg==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "ms": "2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        }
-      }
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "copyfiles": "^2.4.1",
     "del-cli": "^5.1.0",
     "husky": "^8.0.3",
-    "jfrog-cli-go": "^1.54.1",
     "standard-version": "^9.5.0",
     "xml-js": "^1.6.11"
   }


### PR DESCRIPTION
We don't use JFrog here, removing it. 


Ref: https://app.circleci.com/pipelines/github/dequelabs/axe-core-maven-html/966/workflows/b03adc1c-0e40-4a1b-9520-c73612dc88f0/jobs/2426?invite=true#step-103-0_15