### PR TITLE
docs: remove broken CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # axe-core-maven-html
 
-[![CircleCI](https://circleci.com/gh/dequelabs/axe-core-maven-html.svg?style=svg&circle-token=5bd96056d8ab9f52737de9b5d7cc614decbb9819)](https://circleci.com/gh/dequelabs/axe-core-maven-html)
 [![Join our Slack chat](https://img.shields.io/badge/slack-chat-purple.svg?logo=slack)](https://accessibility.deque.com/axe-community)
 
 This repository contains 2 packages, which can be used for automated accessibility testing powered by [axe core][axe-core].


### PR DESCRIPTION
This is always broke. Removing it.

<img width="479" alt="image" src="https://github.com/dequelabs/axe-core-maven-html/assets/41127686/f581e063-19cd-4e00-8ad3-41780b6a3644">


No QA Required.
