### PR TITLE
ci: ensure `sync-master-develop.yml` does not skip on merges to `master`

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -1,12 +1,14 @@
 name: Sync master/develop branches
+
 on:
   pull_request:
-    types: [closed]
     branches: master
+    types: closed
+    
 jobs:
   create_sync_pull_request:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == 'true'
     steps:
       - uses: dequelabs/action-sync-branches@v1
         with:


### PR DESCRIPTION
I had to manually merged master -> into develop (https://github.com/dequelabs/axe-core-maven-html/pull/399). This PR fixes the logic that was skipping the workflow entirely. 

Ref: https://github.com/dequelabs/axe-core-maven-html/actions/workflows/sync-master-develop.yml

Can see [test run workflow](https://github.com/Zidious/test-action-shenanigans/actions/runs/6987254957?pr=25) and test [pull request](https://github.com/Zidious/test-action-shenanigans/pull/25)

No QA Required.