### PR TITLE
test: setup JDK matrix to test multiple popular versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,19 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11, 17]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: "temurin"
+
       - name: Cache npm dependencies
         uses: actions/cache@v3
         id: npm-cache
@@ -21,25 +31,22 @@ jobs:
         id: maven-cache
         with:
           path: ~/.m2/repository
-          key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
           restore-keys: |
-            maven-cache-v1-${{ runner.os }}-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: "8"
-          distribution: "temurin"
+            maven-cache-v1-${{ runner.os }}-${{ matrix.java }}
+
       - name: Install Maven dependencies
         # https://github.com/actions/cache#skipping-steps-based-on-cache-hit
         if: steps.maven-cache.outputs.cache-hit != 'true'
         run: mvn clean install -DskipTests
+
       - name: Install NPM dependencies
         # https://github.com/actions/cache#skipping-steps-based-on-cache-hit
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
-          npm install &&
-          npm --prefix=selenium install &&
-          npm --prefix=playwright install
+          npm ci &&
+          npm --prefix=selenium ci &&
+          npm --prefix=playwright ci
 
   license-check:
     needs: build
@@ -58,6 +65,9 @@ jobs:
     needs: [license-check, build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        java: [8, 11, 17]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3
@@ -73,9 +83,9 @@ jobs:
         id: maven-cache
         with:
           path: ~/.m2/repository
-          key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
           restore-keys: |
-            maven-cache-v1-${{ runner.os }}-
+            maven-cache-v1-${{ runner.os }}-${{ matrix.java }}
       - name: Start fixture server
         run: npm --prefix=playwright start &
       - name: Run Playwright tests
@@ -83,8 +93,11 @@ jobs:
 
   selenium-tests:
     needs: [license-check, build]
-    timeout-minutes: 5
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        java: [8, 11, 17]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -101,9 +114,9 @@ jobs:
         id: maven-cache
         with:
           path: ~/.m2/repository
-          key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          key: maven-cache-v1-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
           restore-keys: |
-            maven-cache-v1-${{ runner.os }}-
+            maven-cache-v1-${{ runner.os }}-${{ matrix.java }}
       - name: Start fixture server
         run: python -m http.server 8001 &
         working-directory: selenium/node_modules/axe-test-fixtures/fixtures


### PR DESCRIPTION
I've been wanting to do this for a while, picked JDK 8, 11 and 17 based on the latest data from the [JetBrains EcoSystem 2023](https://www.jetbrains.com/lp/devecosystem-2023/java/) (thanks for sharing @dbjorge!). Why are we doing this? 

1. Ensure we do not use functions that's only available in later versions of Java as the minimum support we cover is Java 8
2. Ensure that we can still run our API's on later Java versions


No QA required