### PR TITLE
ci: update sync to master to include team-reviewers

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: dequelabs/action-sync-branches@v1
+      - uses: dequelabs/action-sync-branches@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"
-          pr-reviewers: AdnoC,stephenmathieson
+          pr-team-reviewers: axe-api-team
           pr-labels: chore
           pr-template: .github/PULL_REQUEST_TEMPLATE.md

--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: dequelabs/action-sync-branches@v1.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}
           pr-title: "chore: merge master into develop"
           pr-team-reviewers: axe-api-team
           pr-labels: chore


### PR DESCRIPTION
This updates the action to fix the no pr template issue as well as switch to pr team reviewer instead of specific users 
no qa required