### PR TITLE
chore: add note about semver to READMEs

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -2,6 +2,8 @@
 
 > A Playwright Java chainable API integration for axe-core
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -2,6 +2,8 @@
 
 > A Selenium Java chainable API integration for axe-core
 
+This package does not follow Semantic Versioning (SemVer) but instead uses the major and minor version (but not patch version) of axe-core that the package uses. For example, if the API version is v4.7.2, then the axe-core version used by the package will be v4.7.x. The patch version of this package may include bug fixes and new API features but will not introduce breaking changes.
+
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)


### PR DESCRIPTION
As per our policy to add a message about how we don't strictly follow semver to our documentation.

No QA required.