### PR TITLE
chore: Use node to 22 in update-axe-core.yml

### DIFF
--- a/.github/workflows/update-axe-core.yml
+++ b/.github/workflows/update-axe-core.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 22
       - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Just noticed we're using an older version of node. Updating to node 22

No QA Required