### PR TITLE
chore: add create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Create Release
         uses: dequelabs/axe-api-team-public/.github/actions/create-release-v1@main
         with:
-          base: 'main'
+          base: 'master'
           token: ${{ secrets.GH_PROJECT_TOKEN }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,25 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read # Needed to clone the repository
+
+concurrency:
+  group: ${{ github.workflow }}
+  # If this is dispatched multiple times, cancel what is queued.
+  cancel-in-progress: true
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Create Release
+        uses: dequelabs/axe-api-team-public/.github/actions/create-release-v1@main
+        with:
+          base: 'main'
+          token: ${{ secrets.GH_PROJECT_TOKEN }}
+


### PR DESCRIPTION
Adds `.github/workflows/create-release.yml` so releases can be dispatched via the shared `dequelabs/axe-api-team-public/.github/actions/create-release-v1` action.

No QA Required