### PR TITLE
chore: ignore Mockito major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,10 @@ updates:
       # TODO: https://github.com/dequelabs/axe-core-maven-html/issues/378
       - dependency-name: "org.seleniumhq.selenium:selenium-java"
         versions: [">=4.14.0"]
+      # Mockito 5.x requires Java 11+; this project still targets Java 8.
+      # Revisit once Java 8 support is dropped.
+      - dependency-name: "org.mockito:mockito-core"
+        update-types: ["version-update:semver-major"]
     groups:
       # Any updates not caught by the group config will get individual PRs
       maven-low-risk:


### PR DESCRIPTION
## Summary

- Adds a Dependabot ignore rule for major bumps of `org.mockito:mockito-core`.
- Stops the recurring failed PR (most recently [#538](https://github.com/dequelabs/axe-core-maven-html/pull/538)) that attempts to bump Mockito 4.11.0 → 5.x.

## Why

Mockito 5.x requires Java 11+. This project still targets Java 8:

- [`pom.xml`](../blob/develop/pom.xml) sets `maven.compiler.source/target = 1.8`
- [`selenium/pom.xml`](../blob/develop/selenium/pom.xml) sets `<source>8</source>` / `<target>8</target>`
- CI in [`.github/workflows/tests.yml`](../blob/develop/.github/workflows/tests.yml) runs on Java **8**, 11, and 17 — the Java 8 job is what fails the bump with:

  ```
  bad class file: .../mockito-core-5.20.0.jar(org/mockito/ArgumentMatchers.class)
    class file has wrong version 55.0, should be 52.0
  ```

The existing `selenium/pom.xml` already carries a `<!-- versions >4 require Java 11 -->` comment next to the pinned Mockito 4.11.0 — the constraint was known; Dependabot just doesn't see it.

## Blocked on

**This is blocked on dropping Java 8 support.** Once Java 8 is no longer a supported target (i.e. the matrix in `tests.yml` and the compiler `source`/`target` settings move to Java 11+), this ignore rule should be removed and Mockito can be upgraded to 5.x.

## Test plan

- [ ] Merge and confirm Dependabot does not re-open a Mockito 5.x bump on its next run
- [ ] Close [#538](https://github.com/dequelabs/axe-core-maven-html/pull/538) after this lands

No QA required