### PR TITLE
chore: ignore frontend-maven-plugin major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,7 @@ updates:
       - dependency-name: "org.mockito:mockito-core"
         update-types: ["version-update:semver-major"]
       # frontend-maven-plugin 2.x requires Java 17+; this project still targets Java 8.
-      # Revisit once Java 8 support is dropped.
+      # Revisit once the project's minimum supported Java version is 17.
       - dependency-name: "com.github.eirslett:frontend-maven-plugin"
         update-types: ["version-update:semver-major"]
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,10 @@ updates:
       # Revisit once Java 8 support is dropped.
       - dependency-name: "org.mockito:mockito-core"
         update-types: ["version-update:semver-major"]
+      # frontend-maven-plugin 2.x requires Java 17+; this project still targets Java 8.
+      # Revisit once Java 8 support is dropped.
+      - dependency-name: "com.github.eirslett:frontend-maven-plugin"
+        update-types: ["version-update:semver-major"]
     groups:
       # Any updates not caught by the group config will get individual PRs
       maven-low-risk:


### PR DESCRIPTION
## Summary

- Adds a Dependabot ignore rule for major bumps of `com.github.eirslett:frontend-maven-plugin`.
- Stops the recurring failed PR [#558](https://github.com/dequelabs/axe-core-maven-html/pull/558) (1.15.4 → 2.0.0).
- Follow-up to #606 (same pattern, different dependency / different Java floor).

## Why

`frontend-maven-plugin` 2.x requires Java 17. This project still targets Java 8, and even the Java 11 CI matrix entry fails the bump:

```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:2.0.0:install-node-and-npm
[ERROR] The plugin com.github.eirslett:frontend-maven-plugin:2.0.0 has unmet prerequisites:
[ERROR]    Required Java version 17 is not met by current version: 11.0.30
```

Compile/target settings:
- [`pom.xml`](../blob/develop/pom.xml) sets `maven.compiler.source/target = 1.8`
- [`selenium/pom.xml`](../blob/develop/selenium/pom.xml) and [`playwright/pom.xml`](../blob/develop/playwright/pom.xml) reference `frontend-maven-plugin` with `<source>8</source>` / `<target>8</target>` builds
- [`.github/workflows/tests.yml`](../blob/develop/.github/workflows/tests.yml) matrix is Java **8, 11, 17**

## Blocked on

**This is blocked on dropping Java 8 (and Java 11) support.** `frontend-maven-plugin` 2.x needs Java 17 — a higher floor than Mockito 5.x's Java 11. Once the supported Java floor moves to 17, this ignore rule should be removed and the plugin upgraded.

## Test plan

- [ ] Merge and confirm Dependabot does not re-open a frontend-maven-plugin 2.x bump on its next run
- [ ] Close [#558](https://github.com/dequelabs/axe-core-maven-html/pull/558) after this lands

No QA required