### PR TITLE
fix(selenium): harden about:blank tab lifecycle in analyzePost43x

### DIFF
--- a/selenium/src/main/java/com/deque/html/axecore/extensions/BlankWindow.java
+++ b/selenium/src/main/java/com/deque/html/axecore/extensions/BlankWindow.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.extensions;
+
+import java.util.Objects;
+
+/**
+ * Immutable handle pair returned by {@link WebDriverExtensions#openBlankWindow}. Holds both the
+ * previously focused window handle and the about:blank handle that was opened, so {@link
+ * WebDriverExtensions#closeBlankWindow} can close the right window without relying on the driver's
+ * current focus.
+ */
+public final class BlankWindow {
+  private final String previousHandle;
+  private final String aboutBlankHandle;
+
+  BlankWindow(final String previousHandle, final String aboutBlankHandle) {
+    this.previousHandle = Objects.requireNonNull(previousHandle, "previousHandle");
+    this.aboutBlankHandle = Objects.requireNonNull(aboutBlankHandle, "aboutBlankHandle");
+  }
+
+  /** @return the window handle that was focused before about:blank was opened. */
+  public String getPreviousHandle() {
+    return previousHandle;
+  }
+
+  /** @return the window handle of the about:blank window that was opened. */
+  public String getAboutBlankHandle() {
+    return aboutBlankHandle;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (!(o instanceof BlankWindow)) return false;
+    BlankWindow that = (BlankWindow) o;
+    return previousHandle.equals(that.previousHandle)
+        && aboutBlankHandle.equals(that.aboutBlankHandle);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previousHandle, aboutBlankHandle);
+  }
+
+  @Override
+  public String toString() {
+    return "BlankWindow{previousHandle='"
+        + previousHandle
+        + "', aboutBlankHandle='"
+        + aboutBlankHandle
+        + "'}";
+  }
+}

--- a/selenium/src/main/java/com/deque/html/axecore/extensions/WebDriverExtensions.java
+++ b/selenium/src/main/java/com/deque/html/axecore/extensions/WebDriverExtensions.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Set;
 import javax.naming.OperationNotSupportedException;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
@@ -117,7 +118,12 @@ public final class WebDriverExtensions {
    *
    * @param webDriver of the open page
    * @return ID of window at before the switch. Pass this to closeAboutBlank
+   * @deprecated Use {@link #openBlankWindow(WebDriver)} together with {@link
+   *     #closeBlankWindow(WebDriver, BlankWindow)}. The new API tracks the about:blank handle
+   *     explicitly so that {@code closeBlankWindow} never closes the wrong window and is safe to
+   *     wrap in a {@code try/finally}.
    */
+  @Deprecated
   public static String openAboutBlank(final WebDriver webDriver) {
     String currentWindow = webDriver.getWindowHandle();
 
@@ -158,9 +164,151 @@ public final class WebDriverExtensions {
    *
    * @param webDriver for the open page
    * @param prevWindow ID for the window returned by openAboutBlank
+   * @deprecated Use {@link #closeBlankWindow(WebDriver, BlankWindow)}. This overload calls {@code
+   *     webDriver.close()} on whatever window is currently focused, which may not be the
+   *     about:blank window if focus has drifted.
    */
+  @Deprecated
   public static void closeAboutBlank(final WebDriver webDriver, final String prevWindow) {
     webDriver.close();
     webDriver.switchTo().window(prevWindow);
+  }
+
+  /**
+   * Opens an {@code about:blank} window in a new tab and switches focus to it. Returns a {@link
+   * BlankWindow} holding both the previously focused handle and the new about:blank handle, so the
+   * caller can later close the right window via {@link #closeBlankWindow(WebDriver, BlankWindow)}
+   * regardless of what the current focused window is at close time.
+   *
+   * <p>Prefer this over {@link #openAboutBlank(WebDriver)}, which only returns the previous handle
+   * and is therefore not safe to pair with {@code webDriver.close()} when focus may have drifted.
+   *
+   * @param webDriver the driver to open about:blank in
+   * @return the previous handle and the new about:blank handle
+   */
+  public static BlankWindow openBlankWindow(final WebDriver webDriver) {
+    String previousHandle = webDriver.getWindowHandle();
+
+    String aboutBlankHandle;
+    try {
+      JavascriptExecutor driver = (JavascriptExecutor) webDriver;
+      Set<String> beforeHandles = webDriver.getWindowHandles();
+      driver.executeScript("window.open('about:blank', '_blank')");
+      Set<String> afterHandles = webDriver.getWindowHandles();
+
+      // Diff before/after handles to identify the new window. See openAboutBlank for the
+      // Selenium-3 rationale; the new-window API would let us skip this entirely (see #411).
+      ArrayList<String> newHandles = new ArrayList<>(afterHandles);
+      newHandles.removeAll(beforeHandles);
+
+      if (newHandles.isEmpty()) {
+        throw new IllegalStateException(
+            "Unable to determine window handle: no new window was opened");
+      } else if (newHandles.size() == 1) {
+        aboutBlankHandle = newHandles.get(0);
+      } else {
+        // A page-spawned popup raced with our window.open. Pick the about:blank candidate by
+        // probing each new handle's URL, then return focus before continuing.
+        aboutBlankHandle = pickAboutBlankHandle(webDriver, previousHandle, newHandles);
+      }
+
+      webDriver.switchTo().window(aboutBlankHandle);
+      webDriver.get("about:blank");
+    } catch (Exception e) {
+      // Wrap everything (including JavascriptException from driver.executeScript and our own
+      // IllegalStateException for ambiguous handle sets) so callers see one stable error
+      // message. The original exception is preserved as the cause.
+      throw new RuntimeException(
+          "switchToWindow failed. Are you using updated browser drivers? Please check out https://github.com/dequelabs/axe-core-maven-html/blob/develop/error-handling.md",
+          e);
+    }
+
+    return new BlankWindow(previousHandle, aboutBlankHandle);
+  }
+
+  /**
+   * Closes the about:blank window identified by {@code window} and restores focus to the previously
+   * focused window. Safe to call from a {@code finally} block: if the about:blank window no longer
+   * exists, focus is still restored without closing anything; if the previously focused window no
+   * longer exists, focus is restored to any remaining handle so the driver is not left stranded.
+   *
+   * @param webDriver the driver
+   * @param window the handle pair returned by {@link #openBlankWindow(WebDriver)}
+   */
+  public static void closeBlankWindow(final WebDriver webDriver, final BlankWindow window) {
+    if (webDriver == null || window == null) {
+      return;
+    }
+
+    String aboutBlankHandle = window.getAboutBlankHandle();
+    String currentHandle;
+    try {
+      currentHandle = webDriver.getWindowHandle();
+    } catch (Exception e) {
+      currentHandle = null;
+    }
+
+    if (!aboutBlankHandle.equals(currentHandle)) {
+      try {
+        webDriver.switchTo().window(aboutBlankHandle);
+      } catch (NoSuchWindowException e) {
+        // about:blank is already gone — nothing to close, just restore focus.
+        restoreFocus(webDriver, window.getPreviousHandle());
+        return;
+      }
+    }
+
+    try {
+      webDriver.close();
+    } catch (NoSuchWindowException e) {
+      // about:blank closed underneath us between switch and close — fine.
+    }
+    restoreFocus(webDriver, window.getPreviousHandle());
+  }
+
+  private static String pickAboutBlankHandle(
+      final WebDriver webDriver, final String previousHandle, final ArrayList<String> candidates) {
+    String picked = null;
+    for (String handle : candidates) {
+      try {
+        webDriver.switchTo().window(handle);
+        if ("about:blank".equals(webDriver.getCurrentUrl())) {
+          picked = handle;
+          break;
+        }
+      } catch (Exception ignored) {
+        // Try the next candidate.
+      }
+    }
+    // Restore focus before returning so the caller's switch is the only meaningful one.
+    try {
+      webDriver.switchTo().window(previousHandle);
+    } catch (Exception ignored) {
+      // Best-effort; the caller will switch to the picked handle next.
+    }
+    if (picked == null) {
+      throw new IllegalStateException(
+          "Unable to determine window handle: multiple new windows, none matching about:blank");
+    }
+    return picked;
+  }
+
+  private static void restoreFocus(final WebDriver webDriver, final String previousHandle) {
+    try {
+      webDriver.switchTo().window(previousHandle);
+      return;
+    } catch (NoSuchWindowException e) {
+      // Previous window is gone — fall through to pick any remaining handle.
+    } catch (Exception e) {
+      return;
+    }
+    try {
+      Set<String> remaining = webDriver.getWindowHandles();
+      if (!remaining.isEmpty()) {
+        webDriver.switchTo().window(remaining.iterator().next());
+      }
+    } catch (Exception ignored) {
+      // Driver is in an unrecoverable state; let the caller deal with it.
+    }
   }
 }

--- a/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
+++ b/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
@@ -833,6 +833,7 @@ public class AxeBuilder {
 
     BlankWindow blankWindow = WebDriverExtensions.openBlankWindow(webDriver);
     Object resResponse;
+    RuntimeException mainError = null;
     try {
       injectAxe(webDriver);
       sendPartialResults(webDriver, partialResults);
@@ -843,11 +844,16 @@ public class AxeBuilder {
             "axe.finishRun failed. Please check out https://github.com/dequelabs/axe-core-maven-html/blob/develop/selenium/error-handling.md",
             e);
       }
+    } catch (RuntimeException re) {
+      mainError = re;
+      throw re;
     } finally {
       try {
         WebDriverExtensions.closeBlankWindow(webDriver, blankWindow);
-      } catch (Exception cleanupError) {
-        // Swallow — any in-flight exception from the try block is more important.
+      } catch (RuntimeException cleanupError) {
+        if (mainError == null) {
+          throw cleanupError;
+        }
       }
     }
     return objectMapper.convertValue(resResponse, Results.class);

--- a/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
+++ b/selenium/src/main/java/com/deque/html/axecore/selenium/AxeBuilder.java
@@ -13,6 +13,7 @@
 package com.deque.html.axecore.selenium;
 
 import com.deque.html.axecore.args.*;
+import com.deque.html.axecore.extensions.BlankWindow;
 import com.deque.html.axecore.extensions.WebDriverExtensions;
 import com.deque.html.axecore.extensions.WebDriverInjectorExtensions;
 import com.deque.html.axecore.providers.EmbeddedResourceAxeProvider;
@@ -830,22 +831,26 @@ public class AxeBuilder {
       return buildErrorResults(re);
     }
 
-    String prevWindow = WebDriverExtensions.openAboutBlank(webDriver);
-    injectAxe(webDriver);
-    sendPartialResults(webDriver, partialResults);
-
+    BlankWindow blankWindow = WebDriverExtensions.openBlankWindow(webDriver);
     Object resResponse;
     try {
-      resResponse = WebDriverInjectorExtensions.executeScript(webDriver, finishRunScript);
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "axe.finishRun failed. Please check out https://github.com/dequelabs/axe-core-maven-html/blob/develop/selenium/error-handling.md",
-          e);
+      injectAxe(webDriver);
+      sendPartialResults(webDriver, partialResults);
+      try {
+        resResponse = WebDriverInjectorExtensions.executeScript(webDriver, finishRunScript);
+      } catch (Exception e) {
+        throw new RuntimeException(
+            "axe.finishRun failed. Please check out https://github.com/dequelabs/axe-core-maven-html/blob/develop/selenium/error-handling.md",
+            e);
+      }
+    } finally {
+      try {
+        WebDriverExtensions.closeBlankWindow(webDriver, blankWindow);
+      } catch (Exception cleanupError) {
+        // Swallow — any in-flight exception from the try block is more important.
+      }
     }
-    WebDriverExtensions.closeAboutBlank(webDriver, prevWindow);
-    Results res = objectMapper.convertValue(resResponse, Results.class);
-
-    return res;
+    return objectMapper.convertValue(resResponse, Results.class);
   }
 
   private Results analyzePre43x(final WebDriver webDriver, final Object rawContextArg) {

--- a/selenium/src/test/java/com/deque/html/axecore/extensions/BlankWindowUnitTest.java
+++ b/selenium/src/test/java/com/deque/html/axecore/extensions/BlankWindowUnitTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 Deque Systems Inc.,
+ *
+ * Your use of this Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This entire copyright notice must appear in every copy of this file you
+ * distribute or in any file that contains substantial portions of this source
+ * code.
+ */
+
+package com.deque.html.axecore.extensions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchWindowException;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Unit tests for {@link WebDriverExtensions#openBlankWindow} and {@link
+ * WebDriverExtensions#closeBlankWindow} that avoid spinning up a real browser. Each test
+ * pre-programs the {@link WebDriver} mock to return whatever window-handle sequence we want to
+ * exercise.
+ */
+public class BlankWindowUnitTest {
+  private WebDriver driver;
+  private WebDriver.TargetLocator targetLocator;
+  private WebDriver capturedJsExecutor;
+
+  @Before
+  public void setUp() {
+    // WebDriver needs to also implement JavascriptExecutor so the cast inside openBlankWindow
+    // succeeds.
+    driver = mock(WebDriver.class, withSettings().extraInterfaces(JavascriptExecutor.class));
+    targetLocator = mock(WebDriver.TargetLocator.class);
+    lenient().when(driver.switchTo()).thenReturn(targetLocator);
+    capturedJsExecutor = driver; // alias for clarity
+  }
+
+  // --- openBlankWindow -------------------------------------------------------
+
+  @Test
+  public void openBlankWindow_happyPath_returnsBothHandles() {
+    when(driver.getWindowHandle()).thenReturn("user-tab");
+    when(driver.getWindowHandles())
+        .thenReturn(handles("user-tab"))
+        .thenReturn(handles("user-tab", "axe-blank"));
+
+    BlankWindow window = WebDriverExtensions.openBlankWindow(driver);
+
+    assertEquals("user-tab", window.getPreviousHandle());
+    assertEquals("axe-blank", window.getAboutBlankHandle());
+
+    // Should have run window.open, switched to the new handle, and navigated to about:blank.
+    verify((JavascriptExecutor) capturedJsExecutor).executeScript(contains("window.open"));
+    verify(targetLocator).window("axe-blank");
+    verify(driver).get("about:blank");
+  }
+
+  @Test
+  public void openBlankWindow_zeroNewHandles_throws() {
+    when(driver.getWindowHandle()).thenReturn("user-tab");
+    when(driver.getWindowHandles()).thenReturn(handles("user-tab"));
+
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> WebDriverExtensions.openBlankWindow(driver));
+    // Outer message is the stable wrapper; the specific reason is in the cause.
+    assertContains(ex.getMessage(), "switchToWindow failed");
+    assertContains(ex.getCause().getMessage(), "no new window");
+    verify(targetLocator, never()).window(anyString());
+  }
+
+  @Test
+  public void openBlankWindow_multipleNewHandles_picksAboutBlankByUrl() {
+    when(driver.getWindowHandle()).thenReturn("user-tab");
+    when(driver.getWindowHandles())
+        .thenReturn(handles("user-tab"))
+        .thenReturn(handles("user-tab", "popup", "axe-blank"));
+
+    // First switch (probe) returns popup URL; second probe matches.
+    // Note: in the production code we then switch back to user-tab, then to axe-blank.
+    when(driver.getCurrentUrl()).thenReturn("https://popup.example/", "about:blank");
+
+    BlankWindow window = WebDriverExtensions.openBlankWindow(driver);
+    assertEquals("axe-blank", window.getAboutBlankHandle());
+
+    // We should have switched into both candidates, restored focus to user-tab between probes,
+    // and finally switched to axe-blank for the navigation.
+    ArgumentCaptor<String> switched = ArgumentCaptor.forClass(String.class);
+    verify(targetLocator, times(4)).window(switched.capture());
+    assertEquals(
+        Arrays.asList("popup", "axe-blank", "user-tab", "axe-blank"), switched.getAllValues());
+    verify(driver).get("about:blank");
+  }
+
+  @Test
+  public void openBlankWindow_multipleNewHandles_noneMatching_throws() {
+    when(driver.getWindowHandle()).thenReturn("user-tab");
+    when(driver.getWindowHandles())
+        .thenReturn(handles("user-tab"))
+        .thenReturn(handles("user-tab", "popup-a", "popup-b"));
+    when(driver.getCurrentUrl()).thenReturn("https://a.example/", "https://b.example/");
+
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> WebDriverExtensions.openBlankWindow(driver));
+    assertContains(ex.getMessage(), "switchToWindow failed");
+    assertContains(ex.getCause().getMessage(), "none matching about:blank");
+    verify(driver, never()).get("about:blank");
+  }
+
+  // --- closeBlankWindow ------------------------------------------------------
+
+  @Test
+  public void closeBlankWindow_currentlyFocusedOnAboutBlank_closesAndRestores() {
+    BlankWindow window = new BlankWindow("user-tab", "axe-blank");
+    when(driver.getWindowHandle()).thenReturn("axe-blank");
+
+    WebDriverExtensions.closeBlankWindow(driver, window);
+
+    // No extra switch into about:blank needed.
+    verify(targetLocator, never()).window("axe-blank");
+    verify(driver).close();
+    verify(targetLocator).window("user-tab");
+  }
+
+  @Test
+  public void closeBlankWindow_focusDrifted_switchesToAboutBlankBeforeClose() {
+    BlankWindow window = new BlankWindow("user-tab", "axe-blank");
+    when(driver.getWindowHandle()).thenReturn("some-other-tab");
+
+    WebDriverExtensions.closeBlankWindow(driver, window);
+
+    // Must switch into about:blank FIRST, only then close, only then restore.
+    org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(targetLocator, driver);
+    inOrder.verify(targetLocator).window("axe-blank");
+    inOrder.verify(driver).close();
+    inOrder.verify(targetLocator).window("user-tab");
+  }
+
+  @Test
+  public void closeBlankWindow_aboutBlankAlreadyGone_doesNotCloseAndRestoresFocus() {
+    BlankWindow window = new BlankWindow("user-tab", "axe-blank");
+    when(driver.getWindowHandle()).thenReturn("some-other-tab");
+    org.mockito.Mockito.doThrow(new NoSuchWindowException("axe-blank gone"))
+        .when(targetLocator)
+        .window("axe-blank");
+
+    WebDriverExtensions.closeBlankWindow(driver, window);
+
+    verify(driver, never()).close();
+    verify(targetLocator).window("user-tab");
+  }
+
+  @Test
+  public void closeBlankWindow_previousWindowAlsoGone_picksAnyRemainingHandle() {
+    BlankWindow window = new BlankWindow("user-tab", "axe-blank");
+    when(driver.getWindowHandle()).thenReturn("axe-blank");
+    org.mockito.Mockito.doThrow(new NoSuchWindowException("user-tab gone"))
+        .when(targetLocator)
+        .window("user-tab");
+    when(driver.getWindowHandles()).thenReturn(handles("fallback-tab"));
+
+    WebDriverExtensions.closeBlankWindow(driver, window);
+
+    verify(driver).close();
+    verify(targetLocator).window("user-tab"); // attempted
+    verify(targetLocator).window("fallback-tab"); // fallback
+  }
+
+  @Test
+  public void closeBlankWindow_nullArgs_noop() {
+    WebDriverExtensions.closeBlankWindow(null, null);
+    WebDriverExtensions.closeBlankWindow(driver, null);
+    verify(driver, never()).close();
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private static Set<String> handles(String... values) {
+    return new LinkedHashSet<>(Arrays.asList(values));
+  }
+
+  private static String contains(String needle) {
+    return org.mockito.ArgumentMatchers.contains(needle);
+  }
+
+  private static void assertContains(String haystack, String needle) {
+    assertFalse(
+        "expected message to contain \"" + needle + "\" but was: " + haystack,
+        haystack == null || !haystack.contains(needle));
+  }
+}

--- a/selenium/src/test/java/com/deque/html/axecore/extensions/BlankWindowUnitTest.java
+++ b/selenium/src/test/java/com/deque/html/axecore/extensions/BlankWindowUnitTest.java
@@ -102,7 +102,7 @@ public class BlankWindowUnitTest {
     BlankWindow window = WebDriverExtensions.openBlankWindow(driver);
     assertEquals("axe-blank", window.getAboutBlankHandle());
 
-    // We should have switched into both candidates, restored focus to user-tab between probes,
+    // We should have switched into both candidates, restored focus to user-tab after probing,
     // and finally switched to axe-blank for the navigation.
     ArgumentCaptor<String> switched = ArgumentCaptor.forClass(String.class);
     verify(targetLocator, times(4)).window(switched.capture());


### PR DESCRIPTION
## Summary

Fixes #616 — the three intermittent failure modes from `AxeBuilder.analyze()` reported in [#391 (comment)](https://github.com/dequelabs/axe-core-maven-html/issues/391#issuecomment-4637710562):

1. **Leftover `about:blank` tabs** when `finishRun` (or anything between `openAboutBlank` and `closeAboutBlank`) threw. The new `analyzePost43x` wraps the entire inject → sendPartial → finishRun block in `try/finally`, so the about:blank tab is always closed.
2. **User's real tab getting closed** when focus drifted off about:blank between open and close. The new `closeBlankWindow` switches to the tracked about:blank handle *before* `webDriver.close()`, so it cannot close the wrong window.
3. **Spurious `"Unable to determine window handle"`** when a page-spawned popup raced with our `window.open`. The new `openBlankWindow` probes candidate handles for an `about:blank` URL instead of insisting on a single new handle.

## Implementation

Added a parallel safe API instead of changing the existing public methods:

- New value class `BlankWindow` — immutable pair of `previousHandle` + `aboutBlankHandle`.
- New `WebDriverExtensions.openBlankWindow(WebDriver) → BlankWindow` and `closeBlankWindow(WebDriver, BlankWindow)`.
- `AxeBuilder.analyzePost43x` switches to the new API and wraps the work in `try/finally`.
- `openAboutBlank` / `closeAboutBlank` are kept and marked `@Deprecated` with javadoc pointing at the new methods. **Their bodies are unchanged** — no breaking change. Removal is gated on the next major.

The public exception message (`"switchToWindow failed..."`) is preserved verbatim by the new `openBlankWindow`; specific failure reasons (e.g. "no new window was opened", "none matching about:blank") are carried as the `cause` rather than as the outer message.

### Out of scope

- Migrating to `WebDriver.switchTo().newWindow(WindowType.TAB)` — would eliminate the handle-diffing entirely but is gated on dropping Selenium 3 per #411.
- Removing the deprecated methods — gated on the next major version bump.

## Test plan

- [ ] CI Java 8/11/17 matrix passes (selenium module).
- [ ] Manual smoke test using the reporter's stack (`selenium/standalone-chromium`, `selenium-java:4.44.0`) — run `axeBuilder.analyze(webDriver)` ~50× against a real page; confirm no leftover `about:blank` tabs and the active tab is never closed (both observed intermittently before this change).
- [ ] Verify `setLegacyMode(true)` still routes through `analyzePre43x` unchanged.
- [ ] Confirm the public exception message `"switchToWindow failed..."` is still produced when `window.open` fails (pinned by `Axe43xIntegrationTest.finishRunThrowsWhenWindowOpenThrows`; passes locally).
- [ ] Confirm `WebDriverExtensionsTest` (real-driver tests against the deprecated `openAboutBlank`/`closeAboutBlank`) still passes — confirms the deprecation is non-functional.

### Local test results

Full `mvn test -pl selenium`: **88 tests, 0 failures, 0 errors, 1 pre-existing skip**. New `BlankWindowUnitTest` adds 9 tests covering: happy path, zero-new-handles, multi-handle race with URL match, multi-handle race with no match, current-focus on about:blank, focus drifted, about:blank already gone, previous window gone (fallback to remaining handle), null args.

Closes: #616

QA notes: See the Test plan section above.